### PR TITLE
[codex] add github token refresh support

### DIFF
--- a/backend/app/adapters/database_repo.py
+++ b/backend/app/adapters/database_repo.py
@@ -35,6 +35,15 @@ class UserRepository(IUserRepository):
     def __init__(self, session: AsyncSession):
         self.session = session
 
+    async def find_by_id(self, user_id: str) -> Optional[User]:
+        result = await self.session.execute(
+            select(UserModel).where(UserModel.id == user_id)
+        )
+        model = result.scalar_one_or_none()
+        if model:
+            return model.to_domain()
+        return None
+
     async def find_by_github_id(self, github_id: int) -> Optional[User]:
         result = await self.session.execute(
             select(UserModel).where(UserModel.github_id == github_id)
@@ -56,6 +65,10 @@ class UserRepository(IUserRepository):
             model.username = user.username
             model.email = user.email
             model.role = user.role
+            model.github_access_token = user.github_access_token
+            model.github_refresh_token = user.github_refresh_token
+            model.github_access_token_expires_at = user.github_access_token_expires_at
+            model.github_refresh_token_expires_at = user.github_refresh_token_expires_at
         else:
             # Insert new
             model = UserModel(
@@ -64,6 +77,10 @@ class UserRepository(IUserRepository):
                 username=user.username,
                 email=user.email,
                 role=user.role,
+                github_access_token=user.github_access_token,
+                github_refresh_token=user.github_refresh_token,
+                github_access_token_expires_at=user.github_access_token_expires_at,
+                github_refresh_token_expires_at=user.github_refresh_token_expires_at,
             )
             self.session.add(model)
 
@@ -85,6 +102,7 @@ class OrgRepository(IOrgRepository):
             model.github_id = org.github_id
             model.name = org.name
             model.github_access_token = org.github_access_token
+            model.token_owner_user_id = org.token_owner_user_id
         else:
             model = OrgModel(
                 id=org.id,
@@ -92,6 +110,7 @@ class OrgRepository(IOrgRepository):
                 name=org.name,
                 login=org.login,
                 github_access_token=org.github_access_token,
+                token_owner_user_id=org.token_owner_user_id,
             )
             self.session.add(model)
 
@@ -106,7 +125,10 @@ class OrgRepository(IOrgRepository):
 
     async def find_all_with_tokens(self) -> List[Organization]:
         result = await self.session.execute(
-            select(OrgModel).where(OrgModel.github_access_token.is_not(None))
+            select(OrgModel).where(
+                OrgModel.token_owner_user_id.is_not(None)
+                | OrgModel.github_access_token.is_not(None)
+            )
         )
         return [org.to_domain() for org in result.scalars().all()]
 

--- a/backend/app/adapters/models.py
+++ b/backend/app/adapters/models.py
@@ -21,6 +21,10 @@ class UserModel(Base):
     username = Column(String, nullable=False)
     email = Column(String, nullable=True)
     role = Column(String, default="member")
+    github_access_token = Column(String, nullable=True)
+    github_refresh_token = Column(String, nullable=True)
+    github_access_token_expires_at = Column(DateTime, nullable=True)
+    github_refresh_token_expires_at = Column(DateTime, nullable=True)
 
     def to_domain(self) -> User:
         return User(
@@ -29,6 +33,10 @@ class UserModel(Base):
             username=self.username,
             email=self.email,
             role=self.role,
+            github_access_token=self.github_access_token,
+            github_refresh_token=self.github_refresh_token,
+            github_access_token_expires_at=self.github_access_token_expires_at,
+            github_refresh_token_expires_at=self.github_refresh_token_expires_at,
         )
 
 
@@ -40,6 +48,7 @@ class OrgModel(Base):
     name = Column(String, nullable=False)
     login = Column(String, nullable=False)
     github_access_token = Column(String, nullable=True)
+    token_owner_user_id = Column(String, nullable=True)
 
     def to_domain(self) -> Organization:
         return Organization(
@@ -48,6 +57,7 @@ class OrgModel(Base):
             name=self.name,
             login=self.login,
             github_access_token=self.github_access_token,
+            token_owner_user_id=self.token_owner_user_id,
         )
 
 

--- a/backend/app/api/auth_deps.py
+++ b/backend/app/api/auth_deps.py
@@ -1,14 +1,18 @@
 import jwt
-from fastapi import Request, HTTPException, Depends
+from fastapi import HTTPException, Depends
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from sqlalchemy.ext.asyncio import AsyncSession
 import httpx
-from typing import Dict, Any
 
 from app.infrastructure.config import settings
 from app.infrastructure.database import get_db_session
 from app.adapters.database_repo import UserRepository
 from app.domain.entities import User
+from app.usecases.github_auth import (
+    GITHUB_REAUTH_REQUIRED_DETAIL,
+    GitHubAuthorizationExpiredError,
+    GitHubTokenService,
+)
 
 security = HTTPBearer()
 
@@ -26,24 +30,16 @@ async def get_current_user(
         payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
         user_id = payload.get("sub")
 
-        # We also stored the GitHub token to make API requests later
-        github_access_token = payload.get("ght")
-
         if user_id is None:
             raise HTTPException(status_code=401, detail="Invalid token payload")
 
         repo = UserRepository(session)
-        # Note: UserRepository uses find_by_github_id, but our ID is uuid.
-        # We need to adapt it. We will fetch by uuid if needed, or by github_id.
-        # Alternatively, let's just use the repo's find_by_github_id if we store github_id in sub.
-        github_id = payload.get("gh_id")
-        user = await repo.find_by_github_id(int(github_id))
+        user = await repo.find_by_id(str(user_id))
+        if user is None and payload.get("gh_id") is not None:
+            user = await repo.find_by_github_id(int(payload["gh_id"]))
 
         if user is None:
             raise HTTPException(status_code=401, detail="User not found")
-
-        # Attach token to the user object dynamically for downstream API calls
-        user.github_access_token = github_access_token
         return user
 
     except jwt.PyJWTError:
@@ -53,33 +49,27 @@ async def get_current_user(
 
 
 async def verify_org_access(
-    org_id: str, user: User = Depends(get_current_user)
+    org_id: str,
+    user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db_session),
 ) -> User:
     """
     Verify if the authenticated user has access to the specified account or organization.
     A personal GitHub account is always allowed for the logged-in user.
     In a high-scale app, we might cache this in DynamoDB or the DB.
     """
-    if not hasattr(user, "github_access_token") or not user.github_access_token:
-        raise HTTPException(status_code=401, detail="GitHub access token missing")
+    repo = UserRepository(session)
+    token_service = GitHubTokenService()
+    try:
+        user = await token_service.ensure_user_access_token(repo, user)
+    except GitHubAuthorizationExpiredError:
+        raise HTTPException(status_code=401, detail=GITHUB_REAUTH_REQUIRED_DETAIL)
 
     if org_id in {user.username, str(user.github_id)}:
         return user
 
     async with httpx.AsyncClient() as client:
-        orgs_res = await client.get(
-            "https://api.github.com/user/orgs",
-            headers={
-                "Authorization": f"Bearer {user.github_access_token}",
-                "Accept": "application/json",
-            },
-        )
-        if orgs_res.status_code != 200:
-            raise HTTPException(
-                status_code=401, detail="Failed to fetch user orgs from GitHub"
-            )
-
-        orgs = orgs_res.json()
+        orgs = await _fetch_user_orgs(client, repo, token_service, user)
         org_ids = [str(org["id"]) for org in orgs]
         org_logins = [org["login"] for org in orgs]
 
@@ -91,3 +81,53 @@ async def verify_org_access(
             )
 
         return user
+
+
+async def _fetch_user_orgs(
+    client: httpx.AsyncClient,
+    user_repository: UserRepository,
+    token_service: GitHubTokenService,
+    user: User,
+) -> list[dict]:
+    response = await client.get(
+        "https://api.github.com/user/orgs",
+        headers={
+            "Authorization": f"Bearer {user.github_access_token}",
+            "Accept": "application/json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    if response.status_code == 200:
+        return response.json()
+    if response.status_code != 401:
+        raise HTTPException(
+            status_code=401, detail="Failed to fetch user orgs from GitHub"
+        )
+    try:
+        refreshed_user = await token_service.ensure_user_access_token(
+            user_repository,
+            user,
+            force_refresh=True,
+        )
+    except GitHubAuthorizationExpiredError:
+        raise HTTPException(status_code=401, detail=GITHUB_REAUTH_REQUIRED_DETAIL)
+
+    retry_response = await client.get(
+        "https://api.github.com/user/orgs",
+        headers={
+            "Authorization": f"Bearer {refreshed_user.github_access_token}",
+            "Accept": "application/json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    if retry_response.status_code == 200:
+        user.github_access_token = refreshed_user.github_access_token
+        user.github_refresh_token = refreshed_user.github_refresh_token
+        user.github_access_token_expires_at = (
+            refreshed_user.github_access_token_expires_at
+        )
+        user.github_refresh_token_expires_at = (
+            refreshed_user.github_refresh_token_expires_at
+        )
+        return retry_response.json()
+    raise HTTPException(status_code=401, detail=GITHUB_REAUTH_REQUIRED_DETAIL)

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -1,7 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import RedirectResponse
 from sqlalchemy.ext.asyncio import AsyncSession
-import httpx
 import uuid
 import jwt
 import logging
@@ -13,6 +12,7 @@ from app.infrastructure.config import settings
 from app.infrastructure.database import get_db_session
 from app.adapters.database_repo import OrgRepository, UserRepository
 from app.domain.entities import Organization, User
+from app.usecases.github_auth import GitHubAuthorizationExpiredError, GitHubTokenService
 
 router = APIRouter(prefix="/api/v1/auth", tags=["Authentication"])
 logger = logging.getLogger(__name__)
@@ -41,104 +41,74 @@ async def callback(
     if not settings.github_client_id or not settings.github_client_secret:
         raise HTTPException(status_code=500, detail="OAuth credentials not configured")
 
-    async with httpx.AsyncClient() as client:
-        # Exchange code for access token
-        token_res = await client.post(
-            "https://github.com/login/oauth/access_token",
-            headers={"Accept": "application/json"},
-            data={
-                "client_id": settings.github_client_id,
-                "client_secret": settings.github_client_secret,
-                "code": code,
-                "redirect_uri": settings.github_redirect_uri,
-            },
+    token_service = GitHubTokenService()
+    try:
+        token_payload = await token_service.exchange_code_for_tokens(code)
+        github_user = await token_service.fetch_github_user(token_payload.access_token)
+        orgs = await token_service.fetch_user_orgs(token_payload.access_token)
+    except GitHubAuthorizationExpiredError as exc:
+        logger.warning(
+            "GitHub token exchange failed: redirect_uri=%s client_id_suffix=%s code_len=%s detail=%s",
+            settings.github_redirect_uri,
+            (settings.github_client_id or "")[-6:],
+            len(code),
+            str(exc),
         )
-        token_data = token_res.json()
+        raise HTTPException(status_code=400, detail=str(exc))
 
-        if "error" in token_data:
-            logger.warning(
-                "GitHub token exchange failed: status=%s error=%s description=%s redirect_uri=%s client_id_suffix=%s code_len=%s",
-                token_res.status_code,
-                token_data.get("error"),
-                token_data.get("error_description"),
-                settings.github_redirect_uri,
-                (settings.github_client_id or "")[-6:],
-                len(code),
-            )
-            raise HTTPException(
-                status_code=400,
-                detail=token_data.get("error_description", token_data["error"]),
-            )
+    # Save user to database
+    user_repo = UserRepository(session)
+    user = User(
+        id=str(uuid.uuid4()),
+        github_id=github_user["id"],
+        username=github_user["login"],
+        email=github_user.get("email"),
+        role="admin",
+        github_access_token=token_payload.access_token,
+        github_refresh_token=token_payload.refresh_token,
+        github_access_token_expires_at=token_payload.access_token_expires_at,
+        github_refresh_token_expires_at=token_payload.refresh_token_expires_at,
+    )
+    saved_user = await user_repo.save(user)
 
-        access_token = token_data.get("access_token")
-
-        # Fetch GitHub user profile
-        user_res = await client.get(
-            "https://api.github.com/user",
-            headers={
-                "Authorization": f"Bearer {access_token}",
-                "Accept": "application/json",
-            },
+    org_repo = OrgRepository(session)
+    accessible_accounts = {
+        saved_user.username: Organization(
+            id=saved_user.username,
+            github_id=saved_user.github_id,
+            name=saved_user.username,
+            login=saved_user.username,
+            github_access_token=token_payload.access_token,
+            token_owner_user_id=saved_user.id,
         )
-        github_user = user_res.json()
-
-        # Save user to database
-        user_repo = UserRepository(session)
-        user = User(
-            id=str(uuid.uuid4()),
-            github_id=github_user["id"],
-            username=github_user["login"],
-            email=github_user.get("email"),
-            role="admin",
+    }
+    for org in orgs:
+        accessible_accounts[org["login"]] = Organization(
+            id=org["login"],
+            github_id=org["id"],
+            name=org.get("login") or org.get("name") or org["login"],
+            login=org["login"],
+            github_access_token=token_payload.access_token,
+            token_owner_user_id=saved_user.id,
         )
-        saved_user = await user_repo.save(user)
 
-        # Fetch user's organizations
-        orgs_res = await client.get(
-            "https://api.github.com/user/orgs",
-            headers={
-                "Authorization": f"Bearer {access_token}",
-                "Accept": "application/json",
-            },
-        )
-        orgs = orgs_res.json()
-        org_repo = OrgRepository(session)
-        accessible_accounts = {
-            saved_user.username: Organization(
-                id=saved_user.username,
-                github_id=saved_user.github_id,
-                name=saved_user.username,
-                login=saved_user.username,
-                github_access_token=access_token,
-            )
-        }
-        for org in orgs:
-            accessible_accounts[org["login"]] = Organization(
-                id=org["login"],
-                github_id=org["id"],
-                name=org.get("login") or org.get("name") or org["login"],
-                login=org["login"],
-                github_access_token=access_token,
-            )
+    saved_orgs = await org_repo.save_all(list(accessible_accounts.values()))
 
-        saved_orgs = await org_repo.save_all(list(accessible_accounts.values()))
+    # Create JWT Token
+    payload = {
+        "sub": saved_user.id,
+        "gh_id": saved_user.github_id,
+    }
+    app_token = jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM)
 
-        # Create JWT Token
-        payload = {
-            "sub": saved_user.id,
-            "gh_id": saved_user.github_id,
-            "ght": access_token,  # Storing GitHub token in JWT to use it for later org validation
-        }
-        app_token = jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM)
-
-        return {
-            "access_token": app_token,
-            "user": {
-                "id": saved_user.id,
-                "username": saved_user.username,
-                "github_id": saved_user.github_id,
-            },
-            "organizations": [
-                {"id": org.github_id, "login": org.login} for org in saved_orgs
-            ],
-        }
+    return {
+        "access_token": app_token,
+        "user": {
+            "id": saved_user.id,
+            "username": saved_user.username,
+            "github_id": saved_user.github_id,
+        },
+        "organizations": [
+            {"id": org.github_id, "login": org.login} for org in saved_orgs
+        ],
+    }

--- a/backend/app/api/routes/scan.py
+++ b/backend/app/api/routes/scan.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException, status
+import httpx
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.usecases.scanner import ScanRepositoryUseCase
@@ -8,11 +9,16 @@ from app.adapters.database_repo import (
     OrgRepository,
     RepoRepository,
     ScanJobRepository,
+    UserRepository,
 )
 from app.adapters.sqs_scan_queue import SqsScanQueue
 from app.infrastructure.database import get_db_session
 from app.api.auth_deps import verify_org_access
 from app.domain.entities import User
+from app.usecases.github_auth import (
+    GITHUB_REAUTH_REQUIRED_DETAIL,
+    GitHubAuthorizationExpiredError,
+)
 
 router = APIRouter(prefix="/api/v1/scan", tags=["Scan"])
 
@@ -33,6 +39,7 @@ async def get_scan_job_service(
     session: AsyncSession = Depends(get_db_session),
 ) -> ScanJobService:
     org_repository = OrgRepository(session)
+    user_repository = UserRepository(session)
     repo_repository = RepoRepository(session)
     eol_status_repository = EolStatusRepository(session)
     scan_job_repository = ScanJobRepository(session)
@@ -40,6 +47,7 @@ async def get_scan_job_service(
     scan_usecase = ScanRepositoryUseCase(repo_repository, eol_status_repository)
     return ScanJobService(
         org_repository,
+        user_repository,
         repo_repository,
         eol_status_repository,
         scan_job_repository,
@@ -59,6 +67,12 @@ async def get_organization_scan_results(
         return await service.get_scan_results(
             org_id, user.github_access_token, user.username
         )
+    except GitHubAuthorizationExpiredError:
+        raise HTTPException(status_code=401, detail=GITHUB_REAUTH_REQUIRED_DETAIL)
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 401:
+            raise HTTPException(status_code=401, detail=GITHUB_REAUTH_REQUIRED_DETAIL)
+        raise HTTPException(status_code=500, detail=str(exc))
     except HTTPException:
         raise
     except Exception as e:
@@ -80,6 +94,12 @@ async def update_repository_selection(
             user.username,
             payload.selected_repo_ids,
         )
+    except GitHubAuthorizationExpiredError:
+        raise HTTPException(status_code=401, detail=GITHUB_REAUTH_REQUIRED_DETAIL)
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 401:
+            raise HTTPException(status_code=401, detail=GITHUB_REAUTH_REQUIRED_DETAIL)
+        raise HTTPException(status_code=500, detail=str(exc))
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
     except HTTPException:
@@ -117,6 +137,12 @@ async def scan_organization_repos(
     try:
         job = await service.enqueue_scan(org_id, user.username)
         return serialize_scan_job(job)
+    except GitHubAuthorizationExpiredError:
+        raise HTTPException(status_code=401, detail=GITHUB_REAUTH_REQUIRED_DETAIL)
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 401:
+            raise HTTPException(status_code=401, detail=GITHUB_REAUTH_REQUIRED_DETAIL)
+        raise HTTPException(status_code=500, detail=str(exc))
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
     except HTTPException:

--- a/backend/app/domain/entities.py
+++ b/backend/app/domain/entities.py
@@ -21,6 +21,7 @@ class Organization:
     name: str
     login: str
     github_access_token: Optional[str] = None
+    token_owner_user_id: Optional[str] = None
 
 
 @dataclass
@@ -32,6 +33,9 @@ class User:
     role: str = "member"  # Simple RBAC
     organizations: List[Organization] = field(default_factory=list)
     github_access_token: Optional[str] = None
+    github_refresh_token: Optional[str] = None
+    github_access_token_expires_at: Optional[datetime] = None
+    github_refresh_token_expires_at: Optional[datetime] = None
 
 
 @dataclass

--- a/backend/app/domain/interfaces.py
+++ b/backend/app/domain/interfaces.py
@@ -12,6 +12,10 @@ from app.domain.entities import (
 
 class IUserRepository(ABC):
     @abstractmethod
+    async def find_by_id(self, user_id: str) -> Optional[User]:
+        pass
+
+    @abstractmethod
     async def find_by_github_id(self, github_id: int) -> Optional[User]:
         pass
 

--- a/backend/app/infrastructure/init_db.py
+++ b/backend/app/infrastructure/init_db.py
@@ -30,6 +30,8 @@ async def init_db():
             logger.warning(f"Failed to create table '{table.name}': {e}")
 
     await ensure_repo_selection_column()
+    await ensure_user_github_token_columns()
+    await ensure_organization_token_owner_column()
 
 
 async def ensure_repo_selection_column():
@@ -64,6 +66,62 @@ async def ensure_repo_selection_column():
             )
         )
     logger.info("Added repositories.is_selected column")
+
+
+async def _get_existing_columns(table_name: str) -> list[str]:
+    engine = get_engine()
+
+    async with engine.connect() as conn:
+        existing_tables = await conn.run_sync(
+            lambda sync_conn: inspect(sync_conn).get_table_names()
+        )
+    if table_name not in existing_tables:
+        return []
+
+    async with engine.connect() as conn:
+        return await conn.run_sync(
+            lambda sync_conn: [
+                column["name"] for column in inspect(sync_conn).get_columns(table_name)
+            ]
+        )
+
+
+async def ensure_user_github_token_columns():
+    engine = get_engine()
+    existing_columns = await _get_existing_columns("users")
+    if not existing_columns:
+        return
+
+    missing_columns = {
+        "github_access_token": "ALTER TABLE users ADD COLUMN github_access_token VARCHAR",
+        "github_refresh_token": "ALTER TABLE users ADD COLUMN github_refresh_token VARCHAR",
+        "github_access_token_expires_at": (
+            "ALTER TABLE users ADD COLUMN github_access_token_expires_at TIMESTAMP"
+        ),
+        "github_refresh_token_expires_at": (
+            "ALTER TABLE users ADD COLUMN github_refresh_token_expires_at TIMESTAMP"
+        ),
+    }
+
+    for column_name, statement in missing_columns.items():
+        if column_name in existing_columns:
+            continue
+        async with engine.begin() as conn:
+            await conn.execute(text(statement))
+        logger.info("Added users.%s column", column_name)
+
+
+async def ensure_organization_token_owner_column():
+    engine = get_engine()
+    existing_columns = await _get_existing_columns("organizations")
+    if not existing_columns or "token_owner_user_id" in existing_columns:
+        return
+
+    async with engine.begin() as conn:
+        await conn.execute(
+            text("ALTER TABLE organizations " "ADD COLUMN token_owner_user_id VARCHAR")
+        )
+    logger.info("Added organizations.token_owner_user_id column")
 
 
 if __name__ == "__main__":

--- a/backend/app/scan_worker_handler.py
+++ b/backend/app/scan_worker_handler.py
@@ -8,6 +8,7 @@ from app.adapters.database_repo import (
     OrgRepository,
     RepoRepository,
     ScanJobRepository,
+    UserRepository,
 )
 from app.adapters.sqs_scan_queue import SqsScanQueue
 from app.infrastructure.database import get_session_maker
@@ -24,6 +25,7 @@ async def _process_record(record: Dict[str, Any]) -> None:
     async with session_maker() as session:
         try:
             org_repository = OrgRepository(session)
+            user_repository = UserRepository(session)
             repo_repository = RepoRepository(session)
             eol_status_repository = EolStatusRepository(session)
             scan_job_repository = ScanJobRepository(session)
@@ -31,6 +33,7 @@ async def _process_record(record: Dict[str, Any]) -> None:
             scan_usecase = ScanRepositoryUseCase(repo_repository, eol_status_repository)
             worker = ScanJobWorkerService(
                 org_repository,
+                user_repository,
                 repo_repository,
                 eol_status_repository,
                 scan_job_repository,

--- a/backend/app/usecases/github_auth.py
+++ b/backend/app/usecases/github_auth.py
@@ -1,0 +1,176 @@
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any, Dict, Optional
+
+import httpx
+
+from app.domain.entities import User
+from app.domain.interfaces import IUserRepository
+from app.infrastructure.config import settings
+
+GITHUB_REAUTH_REQUIRED_DETAIL = "GitHub authorization expired. Please sign in again."
+GITHUB_TOKEN_REFRESH_LEEWAY = timedelta(minutes=5)
+
+
+class GitHubAuthorizationExpiredError(Exception):
+    pass
+
+
+@dataclass(frozen=True)
+class GitHubTokenPayload:
+    access_token: str
+    refresh_token: Optional[str]
+    access_token_expires_at: Optional[datetime]
+    refresh_token_expires_at: Optional[datetime]
+
+
+def _utcnow_naive() -> datetime:
+    return datetime.now(UTC).replace(tzinfo=None)
+
+
+def _expires_at_from_seconds(seconds: Any) -> Optional[datetime]:
+    if seconds in (None, ""):
+        return None
+    return _utcnow_naive() + timedelta(seconds=int(seconds))
+
+
+class GitHubTokenService:
+    async def exchange_code_for_tokens(self, code: str) -> GitHubTokenPayload:
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                "https://github.com/login/oauth/access_token",
+                headers={"Accept": "application/json"},
+                data={
+                    "client_id": settings.github_client_id,
+                    "client_secret": settings.github_client_secret,
+                    "code": code,
+                    "redirect_uri": settings.github_redirect_uri,
+                },
+            )
+        payload = response.json()
+        return self._parse_token_payload(payload)
+
+    async def refresh_user_access_token(
+        self,
+        user_repository: IUserRepository,
+        user: User,
+    ) -> User:
+        if not settings.github_client_id or not settings.github_client_secret:
+            raise GitHubAuthorizationExpiredError(GITHUB_REAUTH_REQUIRED_DETAIL)
+        if not user.github_refresh_token:
+            raise GitHubAuthorizationExpiredError(GITHUB_REAUTH_REQUIRED_DETAIL)
+
+        refresh_expires_at = user.github_refresh_token_expires_at
+        if (
+            refresh_expires_at is not None
+            and refresh_expires_at <= _utcnow_naive() + GITHUB_TOKEN_REFRESH_LEEWAY
+        ):
+            raise GitHubAuthorizationExpiredError(GITHUB_REAUTH_REQUIRED_DETAIL)
+
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                "https://github.com/login/oauth/access_token",
+                headers={"Accept": "application/json"},
+                data={
+                    "client_id": settings.github_client_id,
+                    "client_secret": settings.github_client_secret,
+                    "grant_type": "refresh_token",
+                    "refresh_token": user.github_refresh_token,
+                },
+            )
+        payload = response.json()
+        token_payload = self._parse_token_payload(payload)
+        user.github_access_token = token_payload.access_token
+        user.github_refresh_token = (
+            token_payload.refresh_token or user.github_refresh_token
+        )
+        user.github_access_token_expires_at = token_payload.access_token_expires_at
+        user.github_refresh_token_expires_at = token_payload.refresh_token_expires_at
+        return await user_repository.save(user)
+
+    async def ensure_user_access_token(
+        self,
+        user_repository: IUserRepository,
+        user: User,
+        *,
+        force_refresh: bool = False,
+    ) -> User:
+        if not user.github_access_token and not user.github_refresh_token:
+            raise GitHubAuthorizationExpiredError(GITHUB_REAUTH_REQUIRED_DETAIL)
+
+        if force_refresh:
+            if not user.github_refresh_token:
+                raise GitHubAuthorizationExpiredError(GITHUB_REAUTH_REQUIRED_DETAIL)
+            return await self.refresh_user_access_token(user_repository, user)
+
+        access_expires_at = user.github_access_token_expires_at
+        if access_expires_at is None:
+            if user.github_access_token:
+                return user
+            return await self.refresh_if_possible(user_repository, user)
+
+        if access_expires_at > _utcnow_naive() + GITHUB_TOKEN_REFRESH_LEEWAY:
+            return user
+
+        return await self.refresh_if_possible(user_repository, user)
+
+    async def refresh_if_possible(
+        self,
+        user_repository: IUserRepository,
+        user: User,
+    ) -> User:
+        if user.github_refresh_token:
+            return await self.refresh_user_access_token(user_repository, user)
+        if user.github_access_token:
+            return user
+        raise GitHubAuthorizationExpiredError(GITHUB_REAUTH_REQUIRED_DETAIL)
+
+    async def fetch_github_user(self, access_token: str) -> Dict[str, Any]:
+        return await self._fetch_json(
+            "https://api.github.com/user",
+            access_token,
+            accept="application/json",
+        )
+
+    async def fetch_user_orgs(self, access_token: str) -> list[dict[str, Any]]:
+        payload = await self._fetch_json(
+            "https://api.github.com/user/orgs",
+            access_token,
+            accept="application/json",
+        )
+        return payload if isinstance(payload, list) else []
+
+    async def _fetch_json(
+        self,
+        url: str,
+        access_token: str,
+        *,
+        accept: str = "application/vnd.github+json",
+    ) -> Any:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                url,
+                headers={
+                    "Authorization": f"Bearer {access_token}",
+                    "Accept": accept,
+                    "X-GitHub-Api-Version": "2022-11-28",
+                },
+            )
+        if response.status_code == 401:
+            raise GitHubAuthorizationExpiredError(GITHUB_REAUTH_REQUIRED_DETAIL)
+        response.raise_for_status()
+        return response.json()
+
+    def _parse_token_payload(self, payload: Dict[str, Any]) -> GitHubTokenPayload:
+        if "error" in payload or not payload.get("access_token"):
+            raise GitHubAuthorizationExpiredError(
+                payload.get("error_description", GITHUB_REAUTH_REQUIRED_DETAIL)
+            )
+        return GitHubTokenPayload(
+            access_token=payload["access_token"],
+            refresh_token=payload.get("refresh_token"),
+            access_token_expires_at=_expires_at_from_seconds(payload.get("expires_in")),
+            refresh_token_expires_at=_expires_at_from_seconds(
+                payload.get("refresh_token_expires_in")
+            ),
+        )

--- a/backend/app/usecases/scan_jobs.py
+++ b/backend/app/usecases/scan_jobs.py
@@ -2,11 +2,14 @@ import logging
 import uuid
 from typing import Any, Dict, List, Optional
 
+import httpx
+
 from app.domain.entities import (
     ACTIVE_SCAN_JOB_STATUSES,
     SCAN_JOB_STATUS_COMPLETED,
     SCAN_JOB_STATUS_FAILED,
     SCAN_JOB_STATUS_PARTIAL_FAILED,
+    Organization,
     ScanJob,
 )
 from app.domain.interfaces import (
@@ -14,6 +17,12 @@ from app.domain.interfaces import (
     IOrgRepository,
     IRepoRepository,
     IScanJobRepository,
+    IUserRepository,
+)
+from app.usecases.github_auth import (
+    GITHUB_REAUTH_REQUIRED_DETAIL,
+    GitHubAuthorizationExpiredError,
+    GitHubTokenService,
 )
 from app.usecases.scanner import FrameworkEolScanner, ScanRepositoryUseCase
 
@@ -27,17 +36,21 @@ class ScanJobService:
     def __init__(
         self,
         org_repository: IOrgRepository,
+        user_repository: IUserRepository,
         repo_repository: IRepoRepository,
         eol_status_repository: IEolStatusRepository,
         scan_job_repository: IScanJobRepository,
         queue,
         scanner_usecase: Optional[ScanRepositoryUseCase] = None,
+        token_service: Optional[GitHubTokenService] = None,
     ):
         self.org_repository = org_repository
+        self.user_repository = user_repository
         self.repo_repository = repo_repository
         self.eol_status_repository = eol_status_repository
         self.scan_job_repository = scan_job_repository
         self.queue = queue
+        self.token_service = token_service or GitHubTokenService()
         self.scanner_usecase = scanner_usecase or ScanRepositoryUseCase(
             repo_repository,
             eol_status_repository,
@@ -72,12 +85,9 @@ class ScanJobService:
             return active_job
 
         organization = await self.org_repository.find_by_login(org_id)
-        if not organization or not organization.github_access_token:
-            raise ValueError("No GitHub token is available for this account")
-
-        repositories = await self.scanner_usecase.list_repositories(
+        repositories = await self._list_repositories_for_organization(
+            organization,
             org_id,
-            organization.github_access_token,
             requested_by,
         )
         if not any(repo.is_selected for repo in repositories):
@@ -142,23 +152,82 @@ class ScanJobService:
             "selected_repository_count": len(normalized_selected_repo_ids),
         }
 
+    async def _list_repositories_for_organization(
+        self,
+        organization: Optional[Organization],
+        org_id: str,
+        user_login: str,
+    ) -> List:
+        if not organization:
+            raise ValueError("No GitHub token is available for this account")
+        access_token = await self._get_organization_access_token(organization)
+        try:
+            return await self.scanner_usecase.list_repositories(
+                org_id,
+                access_token,
+                user_login,
+            )
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code != 401:
+                raise
+        refreshed_token = await self._get_organization_access_token(
+            organization,
+            force_refresh=True,
+        )
+        return await self.scanner_usecase.list_repositories(
+            org_id,
+            refreshed_token,
+            user_login,
+        )
+
+    async def _get_organization_access_token(
+        self,
+        organization: Organization,
+        *,
+        force_refresh: bool = False,
+    ) -> str:
+        if organization.token_owner_user_id:
+            user = await self.user_repository.find_by_id(
+                organization.token_owner_user_id
+            )
+            if user:
+                user = await self.token_service.ensure_user_access_token(
+                    self.user_repository,
+                    user,
+                    force_refresh=force_refresh,
+                )
+                if user.github_access_token:
+                    if organization.github_access_token != user.github_access_token:
+                        organization.github_access_token = user.github_access_token
+                        await self.org_repository.save(organization)
+                    return user.github_access_token
+
+        if organization.github_access_token and not force_refresh:
+            return organization.github_access_token
+
+        raise GitHubAuthorizationExpiredError(GITHUB_REAUTH_REQUIRED_DETAIL)
+
 
 class ScanJobWorkerService:
     def __init__(
         self,
         org_repository: IOrgRepository,
+        user_repository: IUserRepository,
         repo_repository: IRepoRepository,
         eol_status_repository: IEolStatusRepository,
         scan_job_repository: IScanJobRepository,
         queue,
         scanner_usecase: Optional[ScanRepositoryUseCase] = None,
         scanner: Optional[FrameworkEolScanner] = None,
+        token_service: Optional[GitHubTokenService] = None,
     ):
         self.org_repository = org_repository
+        self.user_repository = user_repository
         self.repo_repository = repo_repository
         self.eol_status_repository = eol_status_repository
         self.scan_job_repository = scan_job_repository
         self.queue = queue
+        self.token_service = token_service or GitHubTokenService()
         self.scanner_usecase = scanner_usecase or ScanRepositoryUseCase(
             repo_repository,
             eol_status_repository,
@@ -183,17 +252,27 @@ class ScanJobWorkerService:
             return
 
         organization = await self.org_repository.find_by_login(org_id)
-        if not organization or not organization.github_access_token:
+        if not organization:
             await self.scan_job_repository.finalize(
                 job_id,
                 SCAN_JOB_STATUS_FAILED,
-                "No GitHub token is available for this account",
+                GITHUB_REAUTH_REQUIRED_DETAIL,
             )
             return
 
-        repos = await self.scanner_usecase.list_repositories(
-            org_id, organization.github_access_token, job.requested_by
-        )
+        try:
+            repos = await self._list_repositories_for_organization(
+                organization,
+                org_id,
+                job.requested_by,
+            )
+        except GitHubAuthorizationExpiredError:
+            await self.scan_job_repository.finalize(
+                job_id,
+                SCAN_JOB_STATUS_FAILED,
+                GITHUB_REAUTH_REQUIRED_DETAIL,
+            )
+            return
         selected_repos = [repo for repo in repos if repo.is_selected]
         await self.scan_job_repository.start(job_id, len(selected_repos))
 
@@ -231,9 +310,10 @@ class ScanJobWorkerService:
             return
 
         organization = await self.org_repository.find_by_login(org_id)
-        if not organization or not organization.github_access_token:
+        if not organization:
             updated_job = await self.scan_job_repository.record_repo_failure(
-                job_id, "No GitHub token is available for this account"
+                job_id,
+                GITHUB_REAUTH_REQUIRED_DETAIL,
             )
             await self._finalize_if_ready(updated_job)
             return
@@ -247,11 +327,19 @@ class ScanJobWorkerService:
             return
 
         try:
-            statuses = await self.scanner.scan_repo(
-                repository, organization.github_access_token
+            access_token = await self._get_organization_access_token(organization)
+            statuses = await self._scan_repository_with_retry(
+                organization,
+                repository,
+                access_token,
             )
             await self.eol_status_repository.replace_for_repo(repository.id, statuses)
             updated_job = await self.scan_job_repository.record_repo_success(job_id)
+        except GitHubAuthorizationExpiredError:
+            updated_job = await self.scan_job_repository.record_repo_failure(
+                job_id,
+                GITHUB_REAUTH_REQUIRED_DETAIL,
+            )
         except Exception as exc:
             logger.exception("Failed to scan repository %s", repository.full_name)
             updated_job = await self.scan_job_repository.record_repo_failure(
@@ -287,6 +375,78 @@ class ScanJobWorkerService:
             SCAN_JOB_STATUS_PARTIAL_FAILED,
             error_message,
         )
+
+    async def _list_repositories_for_organization(
+        self,
+        organization: Optional[Organization],
+        org_id: str,
+        user_login: str,
+    ) -> List:
+        if not organization:
+            raise ValueError("No GitHub token is available for this account")
+        access_token = await self._get_organization_access_token(organization)
+        try:
+            return await self.scanner_usecase.list_repositories(
+                org_id,
+                access_token,
+                user_login,
+            )
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code != 401:
+                raise
+        refreshed_token = await self._get_organization_access_token(
+            organization,
+            force_refresh=True,
+        )
+        return await self.scanner_usecase.list_repositories(
+            org_id,
+            refreshed_token,
+            user_login,
+        )
+
+    async def _scan_repository_with_retry(
+        self,
+        organization: Organization,
+        repository,
+        access_token: str,
+    ) -> List:
+        try:
+            return await self.scanner.scan_repo(repository, access_token)
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code != 401:
+                raise
+        refreshed_token = await self._get_organization_access_token(
+            organization,
+            force_refresh=True,
+        )
+        return await self.scanner.scan_repo(repository, refreshed_token)
+
+    async def _get_organization_access_token(
+        self,
+        organization: Organization,
+        *,
+        force_refresh: bool = False,
+    ) -> str:
+        if organization.token_owner_user_id:
+            user = await self.user_repository.find_by_id(
+                organization.token_owner_user_id
+            )
+            if user:
+                user = await self.token_service.ensure_user_access_token(
+                    self.user_repository,
+                    user,
+                    force_refresh=force_refresh,
+                )
+                if user.github_access_token:
+                    if organization.github_access_token != user.github_access_token:
+                        organization.github_access_token = user.github_access_token
+                        await self.org_repository.save(organization)
+                    return user.github_access_token
+
+        if organization.github_access_token and not force_refresh:
+            return organization.github_access_token
+
+        raise GitHubAuthorizationExpiredError(GITHUB_REAUTH_REQUIRED_DETAIL)
 
 
 def serialize_scan_job(job: Optional[ScanJob]) -> Optional[Dict[str, Any]]:

--- a/backend/scripts/run_daily_scan.py
+++ b/backend/scripts/run_daily_scan.py
@@ -6,6 +6,7 @@ from app.adapters.database_repo import (
     RepoRepository,
     EolStatusRepository,
     ScanJobRepository,
+    UserRepository,
 )
 from app.adapters.sqs_scan_queue import SqsScanQueue
 from app.usecases.scan_jobs import ScanJobService
@@ -25,6 +26,7 @@ async def run_daily_scan():
 
     async with AsyncSessionLocal() as session:
         org_repository = OrgRepository(session)
+        user_repository = UserRepository(session)
         organizations = await org_repository.find_all_with_tokens()
 
         if not organizations:
@@ -45,6 +47,7 @@ async def run_daily_scan():
         scanner_usecase = ScanRepositoryUseCase(repo_repository, eol_status_repository)
         scan_job_service = ScanJobService(
             org_repository,
+            user_repository,
             repo_repository,
             eol_status_repository,
             scan_job_repository,

--- a/backend/tests/integration/test_api.py
+++ b/backend/tests/integration/test_api.py
@@ -107,38 +107,38 @@ class TestAuthEndpoints:
         ) as mock_user_repo_cls, patch(
             "app.api.routes.auth.OrgRepository"
         ) as mock_org_repo_cls, patch(
-            "app.api.routes.auth.httpx.AsyncClient"
-        ) as mock_async_client_cls:
+            "app.api.routes.auth.GitHubTokenService"
+        ) as mock_token_service_cls:
             mock_settings.github_client_id = "test-client-id"
             mock_settings.github_client_secret = "test-secret"
             mock_settings.github_redirect_uri = (
                 "https://version-check.dev.devtools.site/auth/callback"
             )
 
-            mock_http_client = AsyncMock()
-            mock_http_client.post.return_value = MagicMock(
-                json=MagicMock(return_value={"access_token": "gho_test"}),
-                status_code=200,
+            mock_token_service = MagicMock()
+            mock_token_service.exchange_code_for_tokens = AsyncMock(
+                return_value=type(
+                    "TokenPayload",
+                    (),
+                    {
+                        "access_token": "gho_test",
+                        "refresh_token": "ghr_test",
+                        "access_token_expires_at": None,
+                        "refresh_token_expires_at": None,
+                    },
+                )()
             )
-            mock_http_client.get.side_effect = [
-                MagicMock(
-                    json=MagicMock(
-                        return_value={
-                            "id": 123,
-                            "login": "octocat",
-                            "email": "octocat@example.com",
-                        }
-                    )
-                ),
-                MagicMock(
-                    json=MagicMock(
-                        return_value=[{"id": 456, "login": "acme", "name": "Acme"}]
-                    )
-                ),
-            ]
-            mock_async_client_cls.return_value.__aenter__.return_value = (
-                mock_http_client
+            mock_token_service.fetch_github_user = AsyncMock(
+                return_value={
+                    "id": 123,
+                    "login": "octocat",
+                    "email": "octocat@example.com",
+                }
             )
+            mock_token_service.fetch_user_orgs = AsyncMock(
+                return_value=[{"id": 456, "login": "acme", "name": "Acme"}]
+            )
+            mock_token_service_cls.return_value = mock_token_service
 
             saved_user = User(
                 id="u1", github_id=123, username="octocat", email="octocat@example.com"

--- a/backend/tests/unit/test_auth_deps.py
+++ b/backend/tests/unit/test_auth_deps.py
@@ -17,8 +17,14 @@ class TestVerifyOrgAccess:
             github_access_token="gho_test",
         )
 
-        with patch("app.api.auth_deps.httpx.AsyncClient") as mock_client_cls:
-            result = await verify_org_access("octocat", user)
+        session = AsyncMock()
+        user_repo = MagicMock()
+        user_repo.find_by_id = AsyncMock(return_value=user)
+
+        with patch("app.api.auth_deps.UserRepository", return_value=user_repo), patch(
+            "app.api.auth_deps.httpx.AsyncClient"
+        ) as mock_client_cls:
+            result = await verify_org_access("octocat", user, session)
 
         assert result == user
         mock_client_cls.assert_not_called()
@@ -36,11 +42,16 @@ class TestVerifyOrgAccess:
             status_code=200,
             json=MagicMock(return_value=[{"id": 1, "login": "acme"}]),
         )
+        session = AsyncMock()
+        user_repo = MagicMock()
+        user_repo.find_by_id = AsyncMock(return_value=user)
 
-        with patch("app.api.auth_deps.httpx.AsyncClient") as mock_client_cls:
+        with patch("app.api.auth_deps.UserRepository", return_value=user_repo), patch(
+            "app.api.auth_deps.httpx.AsyncClient"
+        ) as mock_client_cls:
             mock_client_cls.return_value.__aenter__.return_value = mock_client
 
             with pytest.raises(HTTPException) as exc_info:
-                await verify_org_access("other-org", user)
+                await verify_org_access("other-org", user, session)
 
         assert exc_info.value.status_code == 403

--- a/backend/tests/unit/test_entities.py
+++ b/backend/tests/unit/test_entities.py
@@ -1,6 +1,7 @@
 """Unit tests for domain entities."""
 
 from datetime import datetime
+
 from app.domain.entities import (
     EolStatus,
     Organization,
@@ -22,7 +23,13 @@ class TestUser:
         assert user.organizations == []
 
     def test_create_user_with_all_fields(self):
-        org = Organization(id="o1", github_id=100, name="Org", login="org")
+        org = Organization(
+            id="o1",
+            github_id=100,
+            name="Org",
+            login="org",
+            token_owner_user_id="u2",
+        )
         user = User(
             id="u2",
             github_id=2,
@@ -30,20 +37,31 @@ class TestUser:
             email="bob@example.com",
             role="admin",
             organizations=[org],
+            github_access_token="ghu_test",
+            github_refresh_token="ghr_test",
         )
         assert user.email == "bob@example.com"
         assert user.role == "admin"
         assert len(user.organizations) == 1
         assert user.organizations[0].login == "org"
+        assert user.github_access_token == "ghu_test"
+        assert user.github_refresh_token == "ghr_test"
 
 
 class TestOrganization:
     def test_create_organization(self):
-        org = Organization(id="o1", github_id=100, name="Test Org", login="testorg")
+        org = Organization(
+            id="o1",
+            github_id=100,
+            name="Test Org",
+            login="testorg",
+            token_owner_user_id="u1",
+        )
         assert org.id == "o1"
         assert org.github_id == 100
         assert org.name == "Test Org"
         assert org.login == "testorg"
+        assert org.token_owner_user_id == "u1"
 
 
 class TestRepository:

--- a/backend/tests/unit/test_github_auth.py
+++ b/backend/tests/unit/test_github_auth.py
@@ -1,0 +1,118 @@
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.domain.entities import User
+from app.usecases.github_auth import (
+    GITHUB_REAUTH_REQUIRED_DETAIL,
+    GitHubAuthorizationExpiredError,
+    GitHubTokenService,
+)
+
+
+def _utcnow_naive() -> datetime:
+    return datetime.now(UTC).replace(tzinfo=None)
+
+
+class TestGitHubTokenService:
+    @pytest.mark.asyncio
+    async def test_exchange_code_for_tokens_returns_refresh_metadata(self):
+        service = GitHubTokenService()
+        mock_client = AsyncMock()
+        mock_client.post.return_value = MagicMock(
+            json=MagicMock(
+                return_value={
+                    "access_token": "ghu_test",
+                    "refresh_token": "ghr_test",
+                    "expires_in": 3600,
+                    "refresh_token_expires_in": 7200,
+                }
+            )
+        )
+
+        with patch("app.usecases.github_auth.settings") as mock_settings, patch(
+            "app.usecases.github_auth.httpx.AsyncClient"
+        ) as mock_client_cls:
+            mock_settings.github_client_id = "client-id"
+            mock_settings.github_client_secret = "client-secret"
+            mock_settings.github_redirect_uri = "http://localhost:3000/auth/callback"
+            mock_client_cls.return_value.__aenter__.return_value = mock_client
+
+            payload = await service.exchange_code_for_tokens("test-code")
+
+        assert payload.access_token == "ghu_test"
+        assert payload.refresh_token == "ghr_test"
+        assert payload.access_token_expires_at is not None
+        assert payload.refresh_token_expires_at is not None
+
+    @pytest.mark.asyncio
+    async def test_ensure_user_access_token_refreshes_expired_token(self):
+        service = GitHubTokenService()
+        user_repository = AsyncMock()
+        expired_user = User(
+            id="u1",
+            github_id=1,
+            username="octocat",
+            github_access_token="ghu_old",
+            github_refresh_token="ghr_old",
+            github_access_token_expires_at=_utcnow_naive() - timedelta(minutes=1),
+            github_refresh_token_expires_at=_utcnow_naive() + timedelta(days=1),
+        )
+        saved_user = User(
+            id="u1",
+            github_id=1,
+            username="octocat",
+            github_access_token="ghu_new",
+            github_refresh_token="ghr_new",
+            github_access_token_expires_at=_utcnow_naive() + timedelta(hours=1),
+            github_refresh_token_expires_at=_utcnow_naive() + timedelta(days=30),
+        )
+        user_repository.save = AsyncMock(return_value=saved_user)
+        mock_client = AsyncMock()
+        mock_client.post.return_value = MagicMock(
+            json=MagicMock(
+                return_value={
+                    "access_token": "ghu_new",
+                    "refresh_token": "ghr_new",
+                    "expires_in": 3600,
+                    "refresh_token_expires_in": 86400,
+                }
+            )
+        )
+
+        with patch("app.usecases.github_auth.settings") as mock_settings, patch(
+            "app.usecases.github_auth.httpx.AsyncClient"
+        ) as mock_client_cls:
+            mock_settings.github_client_id = "client-id"
+            mock_settings.github_client_secret = "client-secret"
+            mock_client_cls.return_value.__aenter__.return_value = mock_client
+
+            refreshed_user = await service.ensure_user_access_token(
+                user_repository,
+                expired_user,
+            )
+
+        assert refreshed_user == saved_user
+        user_repository.save.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_force_refresh_requires_refresh_token(self):
+        service = GitHubTokenService()
+        user_repository = AsyncMock()
+        user = User(
+            id="u1",
+            github_id=1,
+            username="octocat",
+            github_access_token="ghu_only",
+        )
+
+        with pytest.raises(
+            GitHubAuthorizationExpiredError,
+            match=GITHUB_REAUTH_REQUIRED_DETAIL,
+        ):
+            await service.ensure_user_access_token(
+                user_repository,
+                user,
+                force_refresh=True,
+            )

--- a/backend/tests/unit/test_models.py
+++ b/backend/tests/unit/test_models.py
@@ -20,6 +20,8 @@ class TestUserModel:
             username="alice",
             email="alice@example.com",
             role="admin",
+            github_access_token="ghu_test",
+            github_refresh_token="ghr_test",
         )
         user = model.to_domain()
         assert user.id == "u1"
@@ -27,6 +29,8 @@ class TestUserModel:
         assert user.username == "alice"
         assert user.email == "alice@example.com"
         assert user.role == "admin"
+        assert user.github_access_token == "ghu_test"
+        assert user.github_refresh_token == "ghr_test"
 
     def test_to_domain_no_email(self):
         model = UserModel(
@@ -88,10 +92,12 @@ class TestOrgModel:
             name="Test Org",
             login="testorg",
             github_access_token="gho_test",
+            token_owner_user_id="u1",
         )
         assert model.id == "o1"
         assert model.login == "testorg"
         assert model.github_access_token == "gho_test"
+        assert model.token_owner_user_id == "u1"
 
 
 class TestEolStatusModel:

--- a/backend/tests/unit/test_scan_jobs.py
+++ b/backend/tests/unit/test_scan_jobs.py
@@ -28,6 +28,7 @@ class TestScanJobService:
         )
 
         org_repository = AsyncMock()
+        user_repository = AsyncMock()
         repo_repository = AsyncMock()
         eol_status_repository = AsyncMock()
         scan_job_repository = AsyncMock()
@@ -36,6 +37,7 @@ class TestScanJobService:
 
         service = ScanJobService(
             org_repository,
+            user_repository,
             repo_repository,
             eol_status_repository,
             scan_job_repository,
@@ -50,6 +52,7 @@ class TestScanJobService:
     @pytest.mark.asyncio
     async def test_enqueue_scan_creates_bootstrap_job(self):
         org_repository = AsyncMock()
+        user_repository = AsyncMock()
         org_repository.find_by_login.return_value = Organization(
             id="octocat",
             github_id=1,
@@ -86,6 +89,7 @@ class TestScanJobService:
 
         service = ScanJobService(
             org_repository,
+            user_repository,
             repo_repository,
             eol_status_repository,
             scan_job_repository,
@@ -109,6 +113,7 @@ class TestScanJobService:
     @pytest.mark.asyncio
     async def test_enqueue_scan_rejects_when_no_repository_is_selected(self):
         org_repository = AsyncMock()
+        user_repository = AsyncMock()
         org_repository.find_by_login.return_value = Organization(
             id="octocat",
             github_id=1,
@@ -137,6 +142,7 @@ class TestScanJobService:
 
         service = ScanJobService(
             org_repository,
+            user_repository,
             repo_repository,
             eol_status_repository,
             scan_job_repository,
@@ -153,6 +159,7 @@ class TestScanJobService:
     @pytest.mark.asyncio
     async def test_update_selection_replaces_selection_set(self):
         org_repository = AsyncMock()
+        user_repository = AsyncMock()
         repo_repository = AsyncMock()
         eol_status_repository = AsyncMock()
         scan_job_repository = AsyncMock()
@@ -183,6 +190,7 @@ class TestScanJobService:
 
         service = ScanJobService(
             org_repository,
+            user_repository,
             repo_repository,
             eol_status_repository,
             scan_job_repository,
@@ -209,6 +217,7 @@ class TestScanJobWorkerService:
         job = ScanJob(id="job-1", org_id="octocat", requested_by="octocat")
 
         org_repository = AsyncMock()
+        user_repository = AsyncMock()
         org_repository.find_by_login.return_value = Organization(
             id="octocat",
             github_id=1,
@@ -233,6 +242,7 @@ class TestScanJobWorkerService:
 
         worker = ScanJobWorkerService(
             org_repository,
+            user_repository,
             repo_repository,
             eol_status_repository,
             scan_job_repository,
@@ -257,6 +267,7 @@ class TestScanJobWorkerService:
         job = ScanJob(id="job-1", org_id="octocat", requested_by="octocat")
 
         org_repository = AsyncMock()
+        user_repository = AsyncMock()
         org_repository.find_by_login.return_value = Organization(
             id="octocat",
             github_id=1,
@@ -302,6 +313,7 @@ class TestScanJobWorkerService:
 
         worker = ScanJobWorkerService(
             org_repository,
+            user_repository,
             repo_repository,
             eol_status_repository,
             scan_job_repository,
@@ -352,6 +364,7 @@ class TestScanJobWorkerService:
         )
 
         org_repository = AsyncMock()
+        user_repository = AsyncMock()
         org_repository.find_by_login.return_value = Organization(
             id="octocat",
             github_id=1,
@@ -379,6 +392,7 @@ class TestScanJobWorkerService:
 
         worker = ScanJobWorkerService(
             org_repository,
+            user_repository,
             repo_repository,
             eol_status_repository,
             scan_job_repository,
@@ -423,6 +437,7 @@ class TestScanJobWorkerService:
         )
 
         org_repository = AsyncMock()
+        user_repository = AsyncMock()
         org_repository.find_by_login.return_value = Organization(
             id="octocat",
             github_id=1,
@@ -440,6 +455,7 @@ class TestScanJobWorkerService:
 
         worker = ScanJobWorkerService(
             org_repository,
+            user_repository,
             repo_repository,
             eol_status_repository,
             scan_job_repository,

--- a/frontend/app/composables/useAuth.ts
+++ b/frontend/app/composables/useAuth.ts
@@ -24,6 +24,7 @@ export const useAuth = () => {
   const token = useState<string | null>('auth.token', () => null)
   const username = useState<string>('auth.username', () => '')
   const organizations = useState<AuthOrganization[]>('auth.organizations', () => [])
+  const authError = useState<string>('auth.error', () => '')
 
   const syncFromStorage = () => {
     if (!import.meta.client) {
@@ -65,13 +66,26 @@ export const useAuth = () => {
 
   const isAuthenticated = computed(() => Boolean(token.value && username.value))
 
+  const setAuthError = (message: string) => {
+    authError.value = message
+  }
+
+  const consumeAuthError = () => {
+    const message = authError.value
+    authError.value = ''
+    return message
+  }
+
   return {
     token,
     username,
     organizations,
+    authError,
     isAuthenticated,
     syncFromStorage,
     setAuth,
     clearAuth,
+    setAuthError,
+    consumeAuthError,
   }
 }

--- a/frontend/app/composables/useAuthedFetch.ts
+++ b/frontend/app/composables/useAuthedFetch.ts
@@ -1,0 +1,76 @@
+type AuthedFetchOptions = Parameters<typeof $fetch>[1]
+const AUTH_ERROR_KEY = 'auth_error_message'
+
+type AuthExpiredError = Error & {
+  isAuthExpired: true
+  statusCode: 401
+}
+
+const isUnauthorizedError = (error: unknown) => {
+  const candidate = error as {
+    status?: number
+    statusCode?: number
+    response?: { status?: number }
+    data?: { status?: number; statusCode?: number }
+  }
+  return candidate?.status === 401
+    || candidate?.statusCode === 401
+    || candidate?.response?.status === 401
+    || candidate?.data?.status === 401
+    || candidate?.data?.statusCode === 401
+}
+
+export const isAuthExpiredError = (error: unknown): error is AuthExpiredError => {
+  return Boolean((error as AuthExpiredError | undefined)?.isAuthExpired)
+}
+
+export const consumeAuthErrorMessage = () => {
+  if (!import.meta.client) {
+    return ''
+  }
+
+  const message = sessionStorage.getItem(AUTH_ERROR_KEY) || ''
+  sessionStorage.removeItem(AUTH_ERROR_KEY)
+  return message
+}
+
+export const useAuthedFetch = () => {
+  const config = useRuntimeConfig()
+  const { token, clearAuth, setAuthError } = useAuth()
+  const { t } = useI18n()
+
+  const authedFetch = async <T>(path: string, options: AuthedFetchOptions = {}) => {
+    const headers: Record<string, string> = {
+      ...((options?.headers as Record<string, string> | undefined) || {})
+    }
+
+    if (token.value) {
+      headers.Authorization = `Bearer ${token.value}`
+    }
+
+    try {
+      return await $fetch<T>(`${config.public.apiBase}${path}`, {
+        ...options,
+        headers
+      })
+    } catch (error) {
+      if (!isUnauthorizedError(error)) {
+        throw error
+      }
+
+      if (import.meta.client) {
+        sessionStorage.setItem(AUTH_ERROR_KEY, t('auth_relogin_required'))
+      }
+      setAuthError(t('auth_relogin_required'))
+      clearAuth()
+      const authError = new Error(t('auth_relogin_required')) as AuthExpiredError
+      authError.isAuthExpired = true
+      authError.statusCode = 401
+      throw authError
+    }
+  }
+
+  return {
+    authedFetch,
+  }
+}

--- a/frontend/app/composables/useMonthlyTokenUsage.ts
+++ b/frontend/app/composables/useMonthlyTokenUsage.ts
@@ -3,8 +3,8 @@ type CurrentMonthUsageResponse = {
 }
 
 export const useMonthlyTokenUsage = () => {
-  const config = useRuntimeConfig()
   const { token } = useAuth()
+  const { authedFetch } = useAuthedFetch()
 
   const totalTokens = useState<number | null>('usage.currentMonth.totalTokens', () => null)
   const isLoading = useState<boolean>('usage.currentMonth.isLoading', () => false)
@@ -25,14 +25,7 @@ export const useMonthlyTokenUsage = () => {
     isLoading.value = true
 
     try {
-      const response = await $fetch<CurrentMonthUsageResponse>(
-        `${config.public.apiBase}/usage/current-month`,
-        {
-          headers: {
-            Authorization: `Bearer ${token.value}`
-          }
-        }
-      )
+      const response = await authedFetch<CurrentMonthUsageResponse>('/usage/current-month')
       totalTokens.value = response.total_tokens
     } catch {
       totalTokens.value = null

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -190,8 +190,8 @@
 </template>
 
 <script setup>
-const config = useRuntimeConfig()
-const { organizations, syncFromStorage } = useAuth()
+const { organizations, syncFromStorage, consumeAuthError } = useAuth()
+const { authedFetch } = useAuthedFetch()
 const { t } = useI18n()
 
 const isScanning = ref(false)
@@ -270,6 +270,11 @@ const scanJobStatusLabel = computed(() => {
 })
 
 function initializeSelectedOrg() {
+  const authErrorMessage = consumeAuthError() || consumeAuthErrorMessage()
+  if (authErrorMessage) {
+    error.value = authErrorMessage
+  }
+
   if (userOrgs.value.length === 0) {
     selectedOrg.value = ''
     repositories.value = []
@@ -364,13 +369,33 @@ function setAllRepositorySelections(isSelected) {
   }))
 }
 
+async function loadScanJob(jobId) {
+  return await authedFetch(`/scan/orgs/${selectedOrg.value}/jobs/${jobId}`)
+}
+
+async function loadRepositories() {
+  return await authedFetch(`/scan/orgs/${selectedOrg.value}`)
+}
+
+async function persistSelection() {
+  return await authedFetch(`/scan/orgs/${selectedOrg.value}/selection`, {
+    method: 'PUT',
+    body: {
+      selected_repo_ids: selectedRepositoryIds.value
+    }
+  })
+}
+
+async function startScan() {
+  return await authedFetch(`/scan/orgs/${selectedOrg.value}`, {
+    method: 'POST'
+  })
+}
+
 async function pollJobStatus(jobId) {
   if (!selectedOrg.value) return
   try {
-    const token = localStorage.getItem('auth_token')
-    const response = await $fetch(`${config.public.apiBase}/scan/orgs/${selectedOrg.value}/jobs/${jobId}`, {
-      headers: token ? { Authorization: `Bearer ${token}` } : {}
-    })
+    const response = await loadScanJob(jobId)
     syncJobState(response)
     if (TERMINAL_SCAN_JOB_STATUSES.has(response.status)) {
       isScanning.value = false
@@ -404,10 +429,7 @@ async function loadData(options = {}) {
     repositories.value = []
   }
   try {
-    const token = localStorage.getItem('auth_token')
-    const response = await $fetch(`${config.public.apiBase}/scan/orgs/${selectedOrg.value}`, {
-      headers: token ? { Authorization: `Bearer ${token}` } : {}
-    })
+    const response = await loadRepositories()
     applyRepositoryResponse(response)
     syncJobState(response.latest_job)
   } catch (err) {
@@ -426,14 +448,7 @@ async function saveSelection() {
   isSavingSelection.value = true
   error.value = ''
   try {
-    const token = localStorage.getItem('auth_token')
-    await $fetch(`${config.public.apiBase}/scan/orgs/${selectedOrg.value}/selection`, {
-      method: 'PUT',
-      body: {
-        selected_repo_ids: selectedRepositoryIds.value
-      },
-      headers: token ? { Authorization: `Bearer ${token}` } : {}
-    })
+    await persistSelection()
     await loadData({ preserveExisting: true })
   } catch (err) {
     if (err.data?.detail) {
@@ -451,11 +466,7 @@ async function scanOrganization() {
   isScanning.value = true
   error.value = ''
   try {
-    const token = localStorage.getItem('auth_token')
-    const response = await $fetch(`${config.public.apiBase}/scan/orgs/${selectedOrg.value}`, {
-      method: 'POST',
-      headers: token ? { Authorization: `Bearer ${token}` } : {}
-    })
+    const response = await startScan()
     syncJobState(response)
   } catch (err) {
     isScanning.value = false

--- a/frontend/i18n/locales/en.json
+++ b/frontend/i18n/locales/en.json
@@ -36,6 +36,7 @@
     "auth_code_already_used": "This authentication response was already used. Please start login again.",
     "auth_generic_failure": "Authentication failed.",
     "auth_load_failed": "Failed to authenticate.",
+    "auth_relogin_required": "Your GitHub authorization expired. Please sign in again.",
     "back_to_dashboard": "Back to Dashboard",
     "default_user": "User",
     "organization": "Account / Organization",

--- a/frontend/i18n/locales/ja.json
+++ b/frontend/i18n/locales/ja.json
@@ -36,6 +36,7 @@
     "auth_code_already_used": "この認証レスポンスはすでに使用済みです。もう一度ログインしてください。",
     "auth_generic_failure": "認証に失敗しました。",
     "auth_load_failed": "認証処理に失敗しました。",
+    "auth_relogin_required": "GitHub認可の有効期限が切れました。再度ログインしてください。",
     "back_to_dashboard": "ダッシュボードに戻る",
     "default_user": "ユーザー",
     "organization": "アカウント / 組織",

--- a/frontend/tests/unit/app.test.ts
+++ b/frontend/tests/unit/app.test.ts
@@ -126,4 +126,20 @@ describe('App', () => {
 
     expect(wrapper.text()).toContain('This month: -')
   })
+
+  it('clears auth state when the usage request returns 401', async () => {
+    fetchMock.mockReset()
+    fetchMock.mockRejectedValue({ statusCode: 401 })
+    localStorage.setItem('auth_token', 'token-1')
+    localStorage.setItem('auth_user', 'alice')
+    localStorage.setItem('auth_orgs', JSON.stringify([{ id: 1, login: 'acme' }]))
+
+    const wrapper = await mountSuspended(AppHarness)
+    await nextTick()
+
+    expect(wrapper.text()).toContain('Login with GitHub')
+    expect(localStorage.getItem('auth_token')).toBeNull()
+    expect(localStorage.getItem('auth_user')).toBeNull()
+    expect(localStorage.getItem('auth_orgs')).toBeNull()
+  })
 })

--- a/frontend/tests/unit/index-page.test.ts
+++ b/frontend/tests/unit/index-page.test.ts
@@ -294,4 +294,15 @@ describe('Index page', () => {
 
     expect(scanButton?.attributes('disabled')).toBeDefined()
   })
+
+  it('clears auth when repository loading returns 401', async () => {
+    fetchMock.mockRejectedValue({ statusCode: 401 })
+
+    const wrapper = await mountSuspended(IndexHarness)
+    await wrapper.vm.$nextTick()
+
+    expect(localStorage.getItem('auth_token')).toBeNull()
+    expect(localStorage.getItem('auth_user')).toBeNull()
+    expect(localStorage.getItem('auth_orgs')).toBeNull()
+  })
 })


### PR DESCRIPTION
## Summary
- add backend-managed GitHub user token refresh support and stop embedding GitHub access tokens in the app JWT
- store refresh metadata on users, link organizations to a token owner, and refresh/retry GitHub API calls for auth and scan flows
- centralize frontend authenticated fetch handling so API 401 responses clear local auth and require re-login cleanly

## Why
Users were being forced to log in again once the GitHub user access token expired. The app kept reusing a stale token from client storage and had no refresh-token path.

## Impact
- GitHub user access tokens are refreshed automatically in normal use
- scan jobs and org access checks use the latest backend-managed token state
- users may need one re-login after deploy so refresh metadata is captured, but daily re-login should no longer be required

## Root cause
The previous implementation stored the GitHub access token inside the app JWT and browser storage, did not persist refresh tokens, and had no refresh flow when GitHub returned 401.

## Validation
- `make test-unit-backend`
- `make test-unit-frontend`
- `make test-integration`
- `make test-lint`
- `make deploy-dev`
