### PR TITLE
[codex] Fix scan job bookkeeping and usage sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,10 @@ test-unit: test-unit-backend test-unit-frontend
 test-unit-backend:
 	cd backend && poetry run pytest tests/unit
 
+.PHONY: test-unit-backend-scan-jobs
+test-unit-backend-scan-jobs:
+	cd backend && poetry run pytest tests/unit/test_scan_jobs.py tests/unit/test_entities.py tests/unit/test_models.py
+
 .PHONY: test-unit-frontend
 test-unit-frontend:
 	cd frontend && npm run test:unit

--- a/backend/app/adapters/database_repo.py
+++ b/backend/app/adapters/database_repo.py
@@ -1,6 +1,6 @@
 from typing import Optional, List
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select, delete, update, desc, func
+from sqlalchemy import case, desc, delete, func, select, update
 import uuid
 from app.domain.interfaces import (
     IUserRepository,
@@ -12,7 +12,11 @@ from app.domain.interfaces import (
 )
 from app.domain.entities import (
     ACTIVE_SCAN_JOB_STATUSES,
+    SCAN_JOB_REPO_STATUS_COMPLETED,
+    SCAN_JOB_REPO_STATUS_FAILED,
+    SCAN_JOB_REPO_STATUS_PENDING,
     SCAN_JOB_STATUS_COMPLETED,
+    ScanJobRepoProgress,
     User,
     Organization,
     Repository,
@@ -26,6 +30,7 @@ from app.adapters.models import (
     RepoModel,
     EolStatusModel,
     ScanJobModel,
+    ScanJobRepoProgressModel,
     TokenUsageEventModel,
 )
 from datetime import UTC, datetime
@@ -297,33 +302,129 @@ class ScanJobRepository(IScanJobRepository):
         await self.session.flush()
         return model.to_domain()
 
-    async def find_by_id(self, job_id: str) -> Optional[ScanJob]:
-        result = await self.session.execute(
-            select(ScanJobModel).where(ScanJobModel.id == job_id)
+    def _progress_summary_subquery(self):
+        return (
+            select(
+                ScanJobRepoProgressModel.job_id.label("job_id"),
+                func.coalesce(
+                    func.sum(
+                        case(
+                            (
+                                ScanJobRepoProgressModel.status
+                                == SCAN_JOB_REPO_STATUS_COMPLETED,
+                                1,
+                            ),
+                            else_=0,
+                        )
+                    ),
+                    0,
+                ).label("completed_repos"),
+                func.coalesce(
+                    func.sum(
+                        case(
+                            (
+                                ScanJobRepoProgressModel.status
+                                == SCAN_JOB_REPO_STATUS_FAILED,
+                                1,
+                            ),
+                            else_=0,
+                        )
+                    ),
+                    0,
+                ).label("failed_repos"),
+            )
+            .group_by(ScanJobRepoProgressModel.job_id)
+            .subquery()
         )
-        model = result.scalar_one_or_none()
-        return model.to_domain() if model else None
+
+    def _scan_job_query(self):
+        progress_summary = self._progress_summary_subquery()
+        return select(
+            ScanJobModel,
+            func.coalesce(
+                progress_summary.c.completed_repos,
+                ScanJobModel.completed_repos,
+            ).label("completed_repos"),
+            func.coalesce(
+                progress_summary.c.failed_repos,
+                ScanJobModel.failed_repos,
+            ).label("failed_repos"),
+        ).outerjoin(progress_summary, progress_summary.c.job_id == ScanJobModel.id)
+
+    def _to_scan_job(
+        self,
+        model: ScanJobModel,
+        completed_repos: Optional[int],
+        failed_repos: Optional[int],
+    ) -> ScanJob:
+        job = model.to_domain()
+        job.completed_repos = int(completed_repos or 0)
+        job.failed_repos = int(failed_repos or 0)
+        return job
+
+    async def _fetch_scan_job(self, statement) -> Optional[ScanJob]:
+        result = await self.session.execute(statement)
+        row = result.first()
+        if not row:
+            return None
+        model, completed_repos, failed_repos = row
+        return self._to_scan_job(model, completed_repos, failed_repos)
+
+    async def _get_progress_counts(self, job_id: str) -> tuple[int, int]:
+        result = await self.session.execute(
+            select(
+                func.coalesce(
+                    func.sum(
+                        case(
+                            (
+                                ScanJobRepoProgressModel.status
+                                == SCAN_JOB_REPO_STATUS_COMPLETED,
+                                1,
+                            ),
+                            else_=0,
+                        )
+                    ),
+                    0,
+                ),
+                func.coalesce(
+                    func.sum(
+                        case(
+                            (
+                                ScanJobRepoProgressModel.status
+                                == SCAN_JOB_REPO_STATUS_FAILED,
+                                1,
+                            ),
+                            else_=0,
+                        )
+                    ),
+                    0,
+                ),
+            ).where(ScanJobRepoProgressModel.job_id == job_id)
+        )
+        completed_repos, failed_repos = result.one()
+        return int(completed_repos or 0), int(failed_repos or 0)
+
+    async def find_by_id(self, job_id: str) -> Optional[ScanJob]:
+        return await self._fetch_scan_job(
+            self._scan_job_query().where(ScanJobModel.id == job_id)
+        )
 
     async def find_latest_by_org(self, org_id: str) -> Optional[ScanJob]:
-        result = await self.session.execute(
-            select(ScanJobModel)
+        return await self._fetch_scan_job(
+            self._scan_job_query()
             .where(ScanJobModel.org_id == org_id)
             .order_by(desc(ScanJobModel.created_at))
             .limit(1)
         )
-        model = result.scalar_one_or_none()
-        return model.to_domain() if model else None
 
     async def find_active_by_org(self, org_id: str) -> Optional[ScanJob]:
-        result = await self.session.execute(
-            select(ScanJobModel)
+        return await self._fetch_scan_job(
+            self._scan_job_query()
             .where(ScanJobModel.org_id == org_id)
             .where(ScanJobModel.status.in_(ACTIVE_SCAN_JOB_STATUSES))
             .order_by(desc(ScanJobModel.created_at))
             .limit(1)
         )
-        model = result.scalar_one_or_none()
-        return model.to_domain() if model else None
 
     async def start(self, job_id: str, total_repos: int) -> Optional[ScanJob]:
         now = _utcnow_naive()
@@ -333,7 +434,10 @@ class ScanJobRepository(IScanJobRepository):
             .values(
                 status="running",
                 total_repos=total_repos,
+                completed_repos=0,
+                failed_repos=0,
                 started_at=now,
+                finished_at=None,
                 updated_at=now,
                 error_message=None,
             )
@@ -344,48 +448,109 @@ class ScanJobRepository(IScanJobRepository):
     async def mark_completed(self, job_id: str) -> Optional[ScanJob]:
         return await self.finalize(job_id, SCAN_JOB_STATUS_COMPLETED)
 
-    async def record_repo_success(self, job_id: str) -> Optional[ScanJob]:
+    async def seed_repo_progress(self, job_id: str, repo_ids: List[str]) -> None:
+        if not repo_ids:
+            return
+
         now = _utcnow_naive()
-        await self.session.execute(
-            update(ScanJobModel)
-            .where(ScanJobModel.id == job_id)
+        existing = await self.session.execute(
+            select(ScanJobRepoProgressModel.repo_id).where(
+                ScanJobRepoProgressModel.job_id == job_id,
+                ScanJobRepoProgressModel.repo_id.in_(repo_ids),
+            )
+        )
+        existing_repo_ids = set(existing.scalars().all())
+
+        for repo_id in repo_ids:
+            if repo_id in existing_repo_ids:
+                continue
+            self.session.add(
+                ScanJobRepoProgressModel(
+                    job_id=job_id,
+                    repo_id=repo_id,
+                    status=SCAN_JOB_REPO_STATUS_PENDING,
+                    created_at=now,
+                    updated_at=now,
+                )
+            )
+        await self.session.flush()
+
+    async def find_repo_progress(
+        self, job_id: str, repo_id: str
+    ) -> Optional[ScanJobRepoProgress]:
+        result = await self.session.execute(
+            select(ScanJobRepoProgressModel).where(
+                ScanJobRepoProgressModel.job_id == job_id,
+                ScanJobRepoProgressModel.repo_id == repo_id,
+            )
+        )
+        model = result.scalar_one_or_none()
+        return model.to_domain() if model else None
+
+    async def record_repo_success(self, job_id: str, repo_id: str) -> Optional[ScanJob]:
+        now = _utcnow_naive()
+        progress_update = await self.session.execute(
+            update(ScanJobRepoProgressModel)
+            .where(ScanJobRepoProgressModel.job_id == job_id)
+            .where(ScanJobRepoProgressModel.repo_id == repo_id)
+            .where(ScanJobRepoProgressModel.status == SCAN_JOB_REPO_STATUS_PENDING)
             .values(
-                completed_repos=ScanJobModel.completed_repos + 1,
+                status=SCAN_JOB_REPO_STATUS_COMPLETED,
+                error_message=None,
                 updated_at=now,
             )
         )
-        await self.session.flush()
+        if progress_update.rowcount:
+            await self.session.execute(
+                update(ScanJobModel)
+                .where(ScanJobModel.id == job_id)
+                .values(updated_at=now)
+            )
+            await self.session.flush()
         return await self.find_by_id(job_id)
 
     async def record_repo_failure(
-        self, job_id: str, error_message: Optional[str]
+        self, job_id: str, repo_id: str, error_message: Optional[str]
     ) -> Optional[ScanJob]:
         now = _utcnow_naive()
-        values = {
-            "failed_repos": ScanJobModel.failed_repos + 1,
-            "updated_at": now,
-        }
-        if error_message is not None:
-            values["error_message"] = error_message
-        await self.session.execute(
-            update(ScanJobModel).where(ScanJobModel.id == job_id).values(**values)
+        progress_update = await self.session.execute(
+            update(ScanJobRepoProgressModel)
+            .where(ScanJobRepoProgressModel.job_id == job_id)
+            .where(ScanJobRepoProgressModel.repo_id == repo_id)
+            .where(ScanJobRepoProgressModel.status == SCAN_JOB_REPO_STATUS_PENDING)
+            .values(
+                status=SCAN_JOB_REPO_STATUS_FAILED,
+                error_message=error_message,
+                updated_at=now,
+            )
         )
-        await self.session.flush()
+        if progress_update.rowcount:
+            await self.session.execute(
+                update(ScanJobModel)
+                .where(ScanJobModel.id == job_id)
+                .values(updated_at=now, error_message=error_message)
+            )
+            await self.session.flush()
         return await self.find_by_id(job_id)
 
     async def finalize(
         self, job_id: str, status: str, error_message: Optional[str] = None
     ) -> Optional[ScanJob]:
         now = _utcnow_naive()
+        completed_repos, failed_repos = await self._get_progress_counts(job_id)
         values = {
             "status": status,
+            "completed_repos": completed_repos,
+            "failed_repos": failed_repos,
             "finished_at": now,
             "updated_at": now,
+            "error_message": error_message,
         }
-        if error_message is not None:
-            values["error_message"] = error_message
         await self.session.execute(
-            update(ScanJobModel).where(ScanJobModel.id == job_id).values(**values)
+            update(ScanJobModel)
+            .where(ScanJobModel.id == job_id)
+            .where(ScanJobModel.status.in_(ACTIVE_SCAN_JOB_STATUSES))
+            .values(**values)
         )
         await self.session.flush()
         return await self.find_by_id(job_id)

--- a/backend/app/adapters/models.py
+++ b/backend/app/adapters/models.py
@@ -1,5 +1,5 @@
 from sqlalchemy.orm import declarative_base
-from sqlalchemy import Column, String, Integer, DateTime, Boolean
+from sqlalchemy import Column, String, Integer, DateTime, Boolean, Index
 from datetime import datetime
 from app.domain.entities import (
     User,
@@ -7,6 +7,7 @@ from app.domain.entities import (
     Organization,
     EolStatus,
     ScanJob,
+    ScanJobRepoProgress,
     TokenUsageEvent,
 )
 
@@ -138,6 +139,31 @@ class ScanJobModel(Base):
             failed_repos=self.failed_repos,
             started_at=self.started_at,
             finished_at=self.finished_at,
+            error_message=self.error_message,
+            created_at=self.created_at,
+            updated_at=self.updated_at,
+        )
+
+
+class ScanJobRepoProgressModel(Base):
+    __tablename__ = "scan_job_repo_progress"
+    __table_args__ = (
+        Index("ix_scan_job_repo_progress_job_id", "job_id"),
+        Index("ix_scan_job_repo_progress_job_id_status", "job_id", "status"),
+    )
+
+    job_id = Column(String, primary_key=True)
+    repo_id = Column(String, primary_key=True)
+    status = Column(String, nullable=False)
+    error_message = Column(String, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    def to_domain(self) -> ScanJobRepoProgress:
+        return ScanJobRepoProgress(
+            job_id=self.job_id,
+            repo_id=self.repo_id,
+            status=self.status,
             error_message=self.error_message,
             created_at=self.created_at,
             updated_at=self.updated_at,

--- a/backend/app/adapters/models.py
+++ b/backend/app/adapters/models.py
@@ -1,5 +1,5 @@
 from sqlalchemy.orm import declarative_base
-from sqlalchemy import Column, String, Integer, DateTime, Boolean, Index
+from sqlalchemy import Column, String, Integer, DateTime, Boolean
 from datetime import datetime
 from app.domain.entities import (
     User,
@@ -147,10 +147,6 @@ class ScanJobModel(Base):
 
 class ScanJobRepoProgressModel(Base):
     __tablename__ = "scan_job_repo_progress"
-    __table_args__ = (
-        Index("ix_scan_job_repo_progress_job_id", "job_id"),
-        Index("ix_scan_job_repo_progress_job_id_status", "job_id", "status"),
-    )
 
     job_id = Column(String, primary_key=True)
     repo_id = Column(String, primary_key=True)

--- a/backend/app/api/routes/scan.py
+++ b/backend/app/api/routes/scan.py
@@ -9,13 +9,14 @@ from app.adapters.database_repo import (
     OrgRepository,
     RepoRepository,
     ScanJobRepository,
+    TokenUsageRepository,
     UserRepository,
 )
 from app.adapters.dynamo_repo import DynamoRepoListCacheRepository
 from app.adapters.sqs_scan_queue import SqsScanQueue
 from app.infrastructure.database import get_db_session
 from app.api.auth_deps import verify_org_access
-from app.domain.entities import User
+from app.domain.entities import ScanJob, User
 from app.usecases.github_auth import (
     GITHUB_REAUTH_REQUIRED_DETAIL,
     GitHubAuthorizationExpiredError,
@@ -65,6 +66,22 @@ async def get_scan_job_service(
         queue,
         scanner_usecase=scan_usecase,
     )
+
+
+async def _serialize_scan_job_with_usage(
+    session: AsyncSession,
+    user_id: str,
+    job: ScanJob | None,
+):
+    payload = serialize_scan_job(job)
+    if not payload:
+        return payload
+
+    token_usage_repository = TokenUsageRepository(session)
+    payload["current_month_total_tokens"] = (
+        await token_usage_repository.get_current_month_total_tokens(user_id)
+    )
+    return payload
 
 
 @router.get("/orgs/{org_id}")
@@ -123,6 +140,7 @@ async def update_repository_selection(
 async def get_scan_job(
     org_id: str,
     job_id: str,
+    session: AsyncSession = Depends(get_db_session),
     service: ScanJobService = Depends(get_scan_job_service),
     user: User = Depends(verify_org_access),
 ):
@@ -131,7 +149,7 @@ async def get_scan_job(
         job = await service.get_job(org_id, job_id)
         if not job:
             raise HTTPException(status_code=404, detail="Scan job not found")
-        return serialize_scan_job(job)
+        return await _serialize_scan_job_with_usage(session, user.id, job)
     except HTTPException:
         raise
     except Exception as e:
@@ -141,13 +159,14 @@ async def get_scan_job(
 @router.post("/orgs/{org_id}", status_code=status.HTTP_202_ACCEPTED)
 async def scan_organization_repos(
     org_id: str,
+    session: AsyncSession = Depends(get_db_session),
     service: ScanJobService = Depends(get_scan_job_service),
     user: User = Depends(verify_org_access),
 ):
     """Queue a new scan for an organization's repos."""
     try:
         job = await service.enqueue_scan(org_id, user.username)
-        return serialize_scan_job(job)
+        return await _serialize_scan_job_with_usage(session, user.id, job)
     except GitHubAuthorizationExpiredError:
         raise HTTPException(status_code=401, detail=GITHUB_REAUTH_REQUIRED_DETAIL)
     except httpx.HTTPStatusError as exc:

--- a/backend/app/domain/entities.py
+++ b/backend/app/domain/entities.py
@@ -8,9 +8,18 @@ SCAN_JOB_STATUS_COMPLETED = "completed"
 SCAN_JOB_STATUS_PARTIAL_FAILED = "partial_failed"
 SCAN_JOB_STATUS_FAILED = "failed"
 
+SCAN_JOB_REPO_STATUS_PENDING = "pending"
+SCAN_JOB_REPO_STATUS_COMPLETED = "completed"
+SCAN_JOB_REPO_STATUS_FAILED = "failed"
+
 ACTIVE_SCAN_JOB_STATUSES = {
     SCAN_JOB_STATUS_QUEUED,
     SCAN_JOB_STATUS_RUNNING,
+}
+
+TERMINAL_SCAN_JOB_REPO_STATUSES = {
+    SCAN_JOB_REPO_STATUS_COMPLETED,
+    SCAN_JOB_REPO_STATUS_FAILED,
 }
 
 
@@ -75,6 +84,20 @@ class ScanJob:
     failed_repos: int = 0
     started_at: Optional[datetime] = None
     finished_at: Optional[datetime] = None
+    error_message: Optional[str] = None
+    created_at: datetime = field(
+        default_factory=lambda: datetime.now(UTC).replace(tzinfo=None)
+    )
+    updated_at: datetime = field(
+        default_factory=lambda: datetime.now(UTC).replace(tzinfo=None)
+    )
+
+
+@dataclass
+class ScanJobRepoProgress:
+    job_id: str
+    repo_id: str
+    status: str = SCAN_JOB_REPO_STATUS_PENDING
     error_message: Optional[str] = None
     created_at: datetime = field(
         default_factory=lambda: datetime.now(UTC).replace(tzinfo=None)

--- a/backend/app/domain/interfaces.py
+++ b/backend/app/domain/interfaces.py
@@ -6,6 +6,7 @@ from app.domain.entities import (
     EolStatus,
     Organization,
     ScanJob,
+    ScanJobRepoProgress,
     TokenUsageEvent,
 )
 
@@ -134,12 +135,22 @@ class IScanJobRepository(ABC):
         pass
 
     @abstractmethod
-    async def record_repo_success(self, job_id: str) -> Optional[ScanJob]:
+    async def seed_repo_progress(self, job_id: str, repo_ids: List[str]) -> None:
+        pass
+
+    @abstractmethod
+    async def find_repo_progress(
+        self, job_id: str, repo_id: str
+    ) -> Optional[ScanJobRepoProgress]:
+        pass
+
+    @abstractmethod
+    async def record_repo_success(self, job_id: str, repo_id: str) -> Optional[ScanJob]:
         pass
 
     @abstractmethod
     async def record_repo_failure(
-        self, job_id: str, error_message: Optional[str]
+        self, job_id: str, repo_id: str, error_message: Optional[str]
     ) -> Optional[ScanJob]:
         pass
 

--- a/backend/app/usecases/scan_jobs.py
+++ b/backend/app/usecases/scan_jobs.py
@@ -8,6 +8,7 @@ import httpx
 
 from app.domain.entities import (
     ACTIVE_SCAN_JOB_STATUSES,
+    TERMINAL_SCAN_JOB_REPO_STATUSES,
     SCAN_JOB_STATUS_COMPLETED,
     SCAN_JOB_STATUS_FAILED,
     SCAN_JOB_STATUS_PARTIAL_FAILED,
@@ -42,6 +43,17 @@ SCAN_JOB_QUEUE_STALE_AFTER = timedelta(minutes=5)
 SCAN_JOB_BOOTSTRAP_STALE_AFTER = timedelta(minutes=3)
 SCAN_JOB_PROGRESS_STALE_AFTER = timedelta(minutes=15)
 SCAN_JOB_REPOSITORY_TIMEOUT_SECONDS = 90
+SCAN_JOB_SERIALIZATION_RETRY_ATTEMPTS = 3
+SCAN_JOB_SERIALIZATION_RETRY_DELAY_SECONDS = 0.2
+
+
+class ScanJobSerializationRetryExhaustedError(RuntimeError):
+    def __init__(self, operation_name: str, original_error: Exception):
+        self.operation_name = operation_name
+        self.original_error = original_error
+        super().__init__(
+            f"{operation_name} failed after serialization retries: {original_error}"
+        )
 
 
 class ScanJobService:
@@ -127,7 +139,7 @@ class ScanJobService:
             )
         except Exception:
             logger.exception("Failed to enqueue scan bootstrap for %s", org_id)
-            await self.scan_job_repository.finalize(
+            await self._finalize_job(
                 created_job.id,
                 SCAN_JOB_STATUS_FAILED,
                 "Failed to enqueue scan bootstrap job",
@@ -232,10 +244,18 @@ class ScanJobService:
     ) -> Optional[ScanJob]:
         if not job or not _is_scan_job_stale(job):
             return job
-        return await self.scan_job_repository.finalize(
+        return await self._finalize_job(
             job.id,
             SCAN_JOB_STATUS_FAILED,
             _get_scan_job_stalled_error_message(job),
+        )
+
+    async def _finalize_job(
+        self, job_id: str, status: str, error_message: Optional[str] = None
+    ) -> Optional[ScanJob]:
+        return await _run_with_serialization_retry(
+            lambda: self.scan_job_repository.finalize(job_id, status, error_message),
+            operation_name=f"finalize scan job {job_id}",
         )
 
 
@@ -281,10 +301,12 @@ class ScanJobWorkerService:
         job = await self.scan_job_repository.find_by_id(job_id)
         if not job or job.status not in ACTIVE_SCAN_JOB_STATUSES:
             return
+        if job.status == "running" and job.total_repos > 0:
+            return
 
         organization = await self.org_repository.find_by_login(org_id)
         if not organization:
-            await self.scan_job_repository.finalize(
+            await self._finalize_job(
                 job_id,
                 SCAN_JOB_STATUS_FAILED,
                 GITHUB_REAUTH_REQUIRED_DETAIL,
@@ -298,17 +320,19 @@ class ScanJobWorkerService:
                 job.requested_by,
             )
         except GitHubAuthorizationExpiredError:
-            await self.scan_job_repository.finalize(
+            await self._finalize_job(
                 job_id,
                 SCAN_JOB_STATUS_FAILED,
                 GITHUB_REAUTH_REQUIRED_DETAIL,
             )
             return
         selected_repos = [repo for repo in repos if repo.is_selected]
-        await self.scan_job_repository.start(job_id, len(selected_repos))
+        selected_repo_ids = [repo.id for repo in selected_repos]
+        await self._seed_repo_progress(job_id, selected_repo_ids)
+        await self._start_job(job_id, len(selected_repo_ids))
 
         if not selected_repos:
-            await self.scan_job_repository.mark_completed(job_id)
+            await self._mark_job_completed(job_id)
             return
 
         repo_messages = [
@@ -327,7 +351,7 @@ class ScanJobWorkerService:
             logger.exception(
                 "Failed to enqueue repository scan messages for %s", org_id
             )
-            await self.scan_job_repository.finalize(
+            await self._finalize_job(
                 job_id,
                 SCAN_JOB_STATUS_FAILED,
                 f"Failed to enqueue repository scan messages: {exc}",
@@ -339,11 +363,25 @@ class ScanJobWorkerService:
         job = await self.scan_job_repository.find_by_id(job_id)
         if not job or job.status not in ACTIVE_SCAN_JOB_STATUSES:
             return
+        repo_progress = await self.scan_job_repository.find_repo_progress(
+            job_id, repo_id
+        )
+        if repo_progress and repo_progress.status in TERMINAL_SCAN_JOB_REPO_STATUSES:
+            await self._finalize_current_job_if_ready(job_id)
+            return
+        if not repo_progress:
+            await self._finalize_job(
+                job_id,
+                SCAN_JOB_STATUS_FAILED,
+                f"Repository progress not found for {repo_id}",
+            )
+            return
 
         organization = await self.org_repository.find_by_login(org_id)
         if not organization:
-            updated_job = await self.scan_job_repository.record_repo_failure(
+            updated_job = await self._record_repo_failure(
                 job_id,
+                repo_id,
                 GITHUB_REAUTH_REQUIRED_DETAIL,
             )
             await self._finalize_if_ready(updated_job)
@@ -351,8 +389,10 @@ class ScanJobWorkerService:
 
         repository = await self.repo_repository.find_by_id(repo_id)
         if not repository:
-            updated_job = await self.scan_job_repository.record_repo_failure(
-                job_id, f"Repository not found: {repo_id}"
+            updated_job = await self._record_repo_failure(
+                job_id,
+                repo_id,
+                f"Repository not found: {repo_id}",
             )
             await self._finalize_if_ready(updated_job)
             return
@@ -366,23 +406,30 @@ class ScanJobWorkerService:
                     access_token,
                 )
             await self.eol_status_repository.replace_for_repo(repository.id, statuses)
-            updated_job = await self.scan_job_repository.record_repo_success(job_id)
-        except GitHubAuthorizationExpiredError:
-            updated_job = await self.scan_job_repository.record_repo_failure(
+            updated_job = await self._record_repo_success(
                 job_id,
+                repo_id,
+                repository.full_name,
+            )
+        except GitHubAuthorizationExpiredError:
+            updated_job = await self._record_repo_failure(
+                job_id,
+                repo_id,
                 GITHUB_REAUTH_REQUIRED_DETAIL,
             )
         except TimeoutError:
-            updated_job = await self.scan_job_repository.record_repo_failure(
+            updated_job = await self._record_repo_failure(
                 job_id,
+                repo_id,
                 "Repository scan timed out for "
                 f"{repository.full_name} after "
                 f"{SCAN_JOB_REPOSITORY_TIMEOUT_SECONDS} seconds",
             )
         except Exception as exc:
             logger.exception("Failed to scan repository %s", repository.full_name)
-            updated_job = await self.scan_job_repository.record_repo_failure(
+            updated_job = await self._record_repo_failure(
                 job_id,
+                repo_id,
                 f"Repository scan failed for {repository.full_name}: {exc}",
             )
 
@@ -397,22 +444,83 @@ class ScanJobWorkerService:
             return
 
         if job.failed_repos == 0:
-            await self.scan_job_repository.finalize(job.id, SCAN_JOB_STATUS_COMPLETED)
+            await self._finalize_job(job.id, SCAN_JOB_STATUS_COMPLETED)
             return
 
         error_message = _build_failure_summary(job)
         if job.completed_repos == 0:
-            await self.scan_job_repository.finalize(
+            await self._finalize_job(
                 job.id,
                 SCAN_JOB_STATUS_FAILED,
                 error_message,
             )
             return
 
-        await self.scan_job_repository.finalize(
+        await self._finalize_job(
             job.id,
             SCAN_JOB_STATUS_PARTIAL_FAILED,
             error_message,
+        )
+
+    async def _start_job(self, job_id: str, total_repos: int) -> Optional[ScanJob]:
+        return await _run_with_serialization_retry(
+            lambda: self.scan_job_repository.start(job_id, total_repos),
+            operation_name=f"start scan job {job_id}",
+        )
+
+    async def _mark_job_completed(self, job_id: str) -> Optional[ScanJob]:
+        return await _run_with_serialization_retry(
+            lambda: self.scan_job_repository.mark_completed(job_id),
+            operation_name=f"complete scan job {job_id}",
+        )
+
+    async def _seed_repo_progress(self, job_id: str, repo_ids: List[str]) -> None:
+        await _run_with_serialization_retry(
+            lambda: self.scan_job_repository.seed_repo_progress(job_id, repo_ids),
+            operation_name=f"seed scan job progress {job_id}",
+        )
+
+    async def _record_repo_success(
+        self, job_id: str, repo_id: str, repository_full_name: str
+    ) -> Optional[ScanJob]:
+        try:
+            return await _run_with_serialization_retry(
+                lambda: self.scan_job_repository.record_repo_success(job_id, repo_id),
+                operation_name=f"record success for {repository_full_name}",
+            )
+        except ScanJobSerializationRetryExhaustedError as exc:
+            logger.warning(
+                "Falling back to failure progress for %s after serialization retries",
+                repository_full_name,
+            )
+            return await self._record_repo_failure(
+                job_id,
+                repo_id,
+                "Repository scan bookkeeping failed for "
+                f"{repository_full_name}: {exc.original_error}",
+            )
+
+    async def _record_repo_failure(
+        self, job_id: str, repo_id: str, error_message: str
+    ) -> Optional[ScanJob]:
+        return await _run_with_serialization_retry(
+            lambda: self.scan_job_repository.record_repo_failure(
+                job_id,
+                repo_id,
+                error_message,
+            ),
+            operation_name=f"record failure for {job_id}/{repo_id}",
+        )
+
+    async def _finalize_current_job_if_ready(self, job_id: str) -> None:
+        await self._finalize_if_ready(await self.scan_job_repository.find_by_id(job_id))
+
+    async def _finalize_job(
+        self, job_id: str, status: str, error_message: Optional[str] = None
+    ) -> Optional[ScanJob]:
+        return await _run_with_serialization_retry(
+            lambda: self.scan_job_repository.finalize(job_id, status, error_message),
+            operation_name=f"finalize scan job {job_id}",
         )
 
     async def _list_repositories_for_organization(
@@ -506,6 +614,42 @@ def serialize_scan_job(job: Optional[ScanJob]) -> Optional[Dict[str, Any]]:
         "created_at": _serialize_utc_datetime(job.created_at),
         "updated_at": _serialize_utc_datetime(job.updated_at),
     }
+
+
+async def _run_with_serialization_retry(operation, operation_name: str):
+    last_error = None
+    for attempt in range(1, SCAN_JOB_SERIALIZATION_RETRY_ATTEMPTS + 1):
+        try:
+            return await operation()
+        except Exception as exc:
+            if not _is_retryable_serialization_error(exc):
+                raise
+            last_error = exc
+            if attempt == SCAN_JOB_SERIALIZATION_RETRY_ATTEMPTS:
+                break
+            logger.warning(
+                "Retrying %s after serialization conflict (%s/%s)",
+                operation_name,
+                attempt,
+                SCAN_JOB_SERIALIZATION_RETRY_ATTEMPTS,
+            )
+            await asyncio.sleep(SCAN_JOB_SERIALIZATION_RETRY_DELAY_SECONDS * attempt)
+
+    raise ScanJobSerializationRetryExhaustedError(
+        operation_name,
+        last_error or RuntimeError("unknown serialization failure"),
+    )
+
+
+def _is_retryable_serialization_error(exc: Exception) -> bool:
+    message = str(exc)
+    if "SerializationError" in message:
+        return True
+    if "please retry" in message:
+        return True
+    if "40001" in message or "OC000" in message:
+        return True
+    return False
 
 
 def _utcnow_naive() -> datetime:

--- a/backend/tests/integration/test_api.py
+++ b/backend/tests/integration/test_api.py
@@ -255,6 +255,10 @@ class TestScanEndpoints:
         from app.api.auth_deps import verify_org_access
         from app.api.routes.scan import get_scan_job_service
 
+        mock_usage_result = MagicMock()
+        mock_usage_result.scalar.return_value = 3456
+        mock_db_session.execute = AsyncMock(return_value=mock_usage_result)
+
         fake_service = MagicMock()
         fake_service.enqueue_scan = AsyncMock(
             return_value=ScanJob(
@@ -298,12 +302,17 @@ class TestScanEndpoints:
             "error_message": None,
             "created_at": "2026-03-28T12:00:00+00:00",
             "updated_at": "2026-03-28T12:00:00+00:00",
+            "current_month_total_tokens": 3456,
         }
 
     @pytest.mark.asyncio
     async def test_get_scan_job_status(self, app_with_mocks, mock_db_session):
         from app.api.auth_deps import verify_org_access
         from app.api.routes.scan import get_scan_job_service
+
+        mock_usage_result = MagicMock()
+        mock_usage_result.scalar.return_value = 4567
+        mock_db_session.execute = AsyncMock(return_value=mock_usage_result)
 
         fake_service = MagicMock()
         fake_service.get_job = AsyncMock(
@@ -349,6 +358,7 @@ class TestScanEndpoints:
             "error_message": None,
             "created_at": "2026-03-28T11:59:55+00:00",
             "updated_at": "2026-03-28T12:00:05+00:00",
+            "current_month_total_tokens": 4567,
         }
 
 

--- a/backend/tests/unit/test_entities.py
+++ b/backend/tests/unit/test_entities.py
@@ -7,6 +7,7 @@ from app.domain.entities import (
     Organization,
     Repository,
     ScanJob,
+    ScanJobRepoProgress,
     TokenUsageEvent,
     User,
 )
@@ -122,6 +123,18 @@ class TestScanJob:
         assert job.failed_repos == 0
         assert isinstance(job.created_at, datetime)
         assert isinstance(job.updated_at, datetime)
+
+
+class TestScanJobRepoProgress:
+    def test_create_scan_job_repo_progress_with_defaults(self):
+        progress = ScanJobRepoProgress(job_id="job-1", repo_id="repo-1")
+
+        assert progress.job_id == "job-1"
+        assert progress.repo_id == "repo-1"
+        assert progress.status == "pending"
+        assert progress.error_message is None
+        assert isinstance(progress.created_at, datetime)
+        assert isinstance(progress.updated_at, datetime)
 
 
 class TestTokenUsageEvent:

--- a/backend/tests/unit/test_models.py
+++ b/backend/tests/unit/test_models.py
@@ -7,6 +7,7 @@ from app.adapters.models import (
     OrgModel,
     RepoModel,
     ScanJobModel,
+    ScanJobRepoProgressModel,
     TokenUsageEventModel,
     UserModel,
 )
@@ -174,3 +175,26 @@ class TestTokenUsageEventModel:
         assert event.output_tokens == 30
         assert event.total_tokens == 150
         assert event.recorded_at == recorded_at
+
+
+class TestScanJobRepoProgressModel:
+    def test_to_domain(self):
+        created_at = datetime(2026, 3, 28, 10, 0, 0)
+        updated_at = datetime(2026, 3, 28, 10, 0, 5)
+        model = ScanJobRepoProgressModel(
+            job_id="job-1",
+            repo_id="repo-1",
+            status="completed",
+            error_message=None,
+            created_at=created_at,
+            updated_at=updated_at,
+        )
+
+        progress = model.to_domain()
+
+        assert progress.job_id == "job-1"
+        assert progress.repo_id == "repo-1"
+        assert progress.status == "completed"
+        assert progress.error_message is None
+        assert progress.created_at == created_at
+        assert progress.updated_at == updated_at

--- a/backend/tests/unit/test_models.py
+++ b/backend/tests/unit/test_models.py
@@ -198,3 +198,6 @@ class TestScanJobRepoProgressModel:
         assert progress.error_message is None
         assert progress.created_at == created_at
         assert progress.updated_at == updated_at
+
+    def test_uses_only_primary_key_constraints_for_dsql_compatibility(self):
+        assert ScanJobRepoProgressModel.__table__.indexes == set()

--- a/backend/tests/unit/test_scan_jobs.py
+++ b/backend/tests/unit/test_scan_jobs.py
@@ -6,22 +6,42 @@ import pytest
 
 import app.usecases.scan_jobs as scan_jobs_module
 from app.domain.entities import (
+    SCAN_JOB_REPO_STATUS_COMPLETED,
+    SCAN_JOB_REPO_STATUS_PENDING,
     SCAN_JOB_STATUS_FAILED,
     SCAN_JOB_STATUS_PARTIAL_FAILED,
     EolStatus,
     Organization,
     Repository,
     ScanJob,
+    ScanJobRepoProgress,
 )
 from app.usecases.scan_jobs import (
     SCAN_JOB_BOOTSTRAP_STALLED_ERROR_MESSAGE,
     SCAN_JOB_MESSAGE_BOOTSTRAP,
     SCAN_JOB_MESSAGE_REPOSITORY,
     SCAN_JOB_PROGRESS_STALLED_ERROR_MESSAGE,
+    ScanJobSerializationRetryExhaustedError,
     ScanJobService,
     ScanJobWorkerService,
+    _is_retryable_serialization_error,
     serialize_scan_job,
 )
+
+
+def make_repo_progress(
+    repo_id: str,
+    *,
+    job_id: str = "job-1",
+    status: str = SCAN_JOB_REPO_STATUS_PENDING,
+    error_message: str | None = None,
+) -> ScanJobRepoProgress:
+    return ScanJobRepoProgress(
+        job_id=job_id,
+        repo_id=repo_id,
+        status=status,
+        error_message=error_message,
+    )
 
 
 class TestScanJobService:
@@ -745,6 +765,7 @@ class TestScanJobWorkerService:
             }
         )
 
+        scan_job_repository.seed_repo_progress.assert_awaited_once_with("job-1", [])
         scan_job_repository.start.assert_awaited_once_with("job-1", 0)
         scan_job_repository.mark_completed.assert_awaited_once_with("job-1")
         queue.send_messages.assert_not_awaited()
@@ -822,6 +843,10 @@ class TestScanJobWorkerService:
             "octocat",
             use_cache=True,
         )
+        scan_job_repository.seed_repo_progress.assert_awaited_once_with(
+            "job-1",
+            ["repo-1"],
+        )
         scan_job_repository.start.assert_awaited_once_with("job-1", 1)
         queue.send_messages.assert_awaited_once_with(
             [
@@ -833,6 +858,39 @@ class TestScanJobWorkerService:
                 }
             ]
         )
+
+    @pytest.mark.asyncio
+    async def test_bootstrap_skips_requeued_running_job_after_progress_started(self):
+        job = ScanJob(
+            id="job-1",
+            org_id="octocat",
+            requested_by="octocat",
+            status="running",
+            total_repos=2,
+        )
+        scan_job_repository = AsyncMock()
+        scan_job_repository.find_by_id.return_value = job
+
+        worker = ScanJobWorkerService(
+            AsyncMock(),
+            AsyncMock(),
+            AsyncMock(),
+            AsyncMock(),
+            scan_job_repository,
+            AsyncMock(),
+            scanner_usecase=AsyncMock(),
+        )
+
+        await worker.process_message(
+            {
+                "message_type": SCAN_JOB_MESSAGE_BOOTSTRAP,
+                "job_id": "job-1",
+                "org_id": "octocat",
+            }
+        )
+
+        scan_job_repository.start.assert_not_awaited()
+        scan_job_repository.seed_repo_progress.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_repository_scan_finalizes_partial_failure(self):
@@ -878,6 +936,9 @@ class TestScanJobWorkerService:
         eol_status_repository = AsyncMock()
         scan_job_repository = AsyncMock()
         scan_job_repository.find_by_id.return_value = initial_job
+        scan_job_repository.find_repo_progress.return_value = make_repo_progress(
+            "repo-1"
+        )
         scan_job_repository.record_repo_failure.return_value = updated_job
         queue = AsyncMock()
         scanner = AsyncMock()
@@ -906,6 +967,11 @@ class TestScanJobWorkerService:
         finalize_args = scan_job_repository.finalize.await_args.args
         assert finalize_args[0] == "job-1"
         assert finalize_args[1] == SCAN_JOB_STATUS_PARTIAL_FAILED
+        scan_job_repository.record_repo_failure.assert_awaited_once_with(
+            "job-1",
+            "repo-1",
+            "Repository scan failed for octocat/broken: boom",
+        )
 
     @pytest.mark.asyncio
     async def test_repository_scan_finalizes_failed_when_all_repos_fail(self):
@@ -943,6 +1009,9 @@ class TestScanJobWorkerService:
         eol_status_repository = AsyncMock()
         scan_job_repository = AsyncMock()
         scan_job_repository.find_by_id.return_value = initial_job
+        scan_job_repository.find_repo_progress.return_value = make_repo_progress(
+            "repo-1"
+        )
         scan_job_repository.record_repo_failure.return_value = updated_job
         queue = AsyncMock()
 
@@ -968,6 +1037,11 @@ class TestScanJobWorkerService:
         finalize_args = scan_job_repository.finalize.await_args.args
         assert finalize_args[0] == "job-1"
         assert finalize_args[1] == SCAN_JOB_STATUS_FAILED
+        scan_job_repository.record_repo_failure.assert_awaited_once_with(
+            "job-1",
+            "repo-1",
+            "Repository not found: repo-1",
+        )
 
     @pytest.mark.asyncio
     async def test_repository_scan_records_timeout_as_failure(self, monkeypatch):
@@ -1020,6 +1094,9 @@ class TestScanJobWorkerService:
         eol_status_repository = AsyncMock()
         scan_job_repository = AsyncMock()
         scan_job_repository.find_by_id.return_value = initial_job
+        scan_job_repository.find_repo_progress.return_value = make_repo_progress(
+            "repo-1"
+        )
         scan_job_repository.record_repo_failure.return_value = updated_job
         queue = AsyncMock()
         scanner = AsyncMock()
@@ -1051,9 +1128,163 @@ class TestScanJobWorkerService:
 
         scan_job_repository.record_repo_failure.assert_awaited_once_with(
             "job-1",
+            "repo-1",
             "Repository scan timed out for octocat/app after 0.01 seconds",
         )
         scan_job_repository.finalize.assert_awaited_once()
         finalize_args = scan_job_repository.finalize.await_args.args
         assert finalize_args[0] == "job-1"
         assert finalize_args[1] == SCAN_JOB_STATUS_FAILED
+
+    @pytest.mark.asyncio
+    async def test_repository_scan_skips_duplicate_terminal_repo_and_retries_finalization(
+        self,
+    ):
+        initial_job = ScanJob(
+            id="job-1",
+            org_id="octocat",
+            requested_by="octocat",
+            status="running",
+            total_repos=1,
+            completed_repos=1,
+            failed_repos=0,
+        )
+
+        scan_job_repository = AsyncMock()
+        scan_job_repository.find_by_id.return_value = initial_job
+        scan_job_repository.find_repo_progress.return_value = make_repo_progress(
+            "repo-1",
+            status=SCAN_JOB_REPO_STATUS_COMPLETED,
+        )
+
+        worker = ScanJobWorkerService(
+            AsyncMock(),
+            AsyncMock(),
+            AsyncMock(),
+            AsyncMock(),
+            scan_job_repository,
+            AsyncMock(),
+        )
+
+        await worker.process_message(
+            {
+                "message_type": SCAN_JOB_MESSAGE_REPOSITORY,
+                "job_id": "job-1",
+                "org_id": "octocat",
+                "repo_id": "repo-1",
+            }
+        )
+
+        scan_job_repository.record_repo_success.assert_not_awaited()
+        scan_job_repository.finalize.assert_awaited_once_with(
+            "job-1",
+            "completed",
+            None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_repository_scan_falls_back_to_failed_progress_when_success_retry_exhausts(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(
+            scan_jobs_module, "SCAN_JOB_SERIALIZATION_RETRY_DELAY_SECONDS", 0
+        )
+        initial_job = ScanJob(
+            id="job-1",
+            org_id="octocat",
+            requested_by="octocat",
+            status="running",
+            total_repos=1,
+            completed_repos=0,
+            failed_repos=0,
+        )
+        failed_job = ScanJob(
+            id="job-1",
+            org_id="octocat",
+            requested_by="octocat",
+            status="running",
+            total_repos=1,
+            completed_repos=0,
+            failed_repos=1,
+            error_message="Repository scan bookkeeping failed for octocat/app: please retry",
+        )
+
+        org_repository = AsyncMock()
+        user_repository = AsyncMock()
+        org_repository.find_by_login.return_value = Organization(
+            id="octocat",
+            github_id=1,
+            name="octocat",
+            login="octocat",
+            github_access_token="gho_test",
+        )
+        repo_repository = AsyncMock()
+        repo_repository.find_by_id.return_value = Repository(
+            id="repo-1",
+            github_id=1,
+            name="app",
+            full_name="octocat/app",
+            org_id="octocat",
+            owner_login="octocat",
+            default_branch="main",
+        )
+        eol_status_repository = AsyncMock()
+        scan_job_repository = AsyncMock()
+        scan_job_repository.find_by_id.return_value = initial_job
+        scan_job_repository.find_repo_progress.return_value = make_repo_progress(
+            "repo-1"
+        )
+        scan_job_repository.record_repo_success.side_effect = RuntimeError(
+            "SerializationError: please retry"
+        )
+        scan_job_repository.record_repo_failure.return_value = failed_job
+        scanner = AsyncMock()
+        scanner.scan_repo.return_value = []
+
+        worker = ScanJobWorkerService(
+            org_repository,
+            user_repository,
+            repo_repository,
+            eol_status_repository,
+            scan_job_repository,
+            AsyncMock(),
+            scanner=scanner,
+        )
+
+        await worker.process_message(
+            {
+                "message_type": SCAN_JOB_MESSAGE_REPOSITORY,
+                "job_id": "job-1",
+                "org_id": "octocat",
+                "repo_id": "repo-1",
+            }
+        )
+
+        assert scan_job_repository.record_repo_success.await_count == 3
+        scan_job_repository.record_repo_failure.assert_awaited_once()
+        failure_args = scan_job_repository.record_repo_failure.await_args.args
+        assert failure_args[:2] == ("job-1", "repo-1")
+        assert "Repository scan bookkeeping failed for octocat/app" in failure_args[2]
+        scan_job_repository.finalize.assert_awaited_once_with(
+            "job-1",
+            SCAN_JOB_STATUS_FAILED,
+            "1 of 1 repositories failed during scan. Last error: "
+            + failed_job.error_message,
+        )
+
+
+class TestSerializationHelpers:
+    def test_detects_retryable_serialization_errors(self):
+        assert _is_retryable_serialization_error(
+            RuntimeError("SerializationError: please retry (OC000)")
+        )
+
+    def test_scan_job_retry_exhausted_error_preserves_original_error(self):
+        original_error = RuntimeError("SerializationError: please retry")
+
+        error = ScanJobSerializationRetryExhaustedError(
+            "record success",
+            original_error,
+        )
+
+        assert error.original_error is original_error

--- a/frontend/app/composables/useMonthlyTokenUsage.ts
+++ b/frontend/app/composables/useMonthlyTokenUsage.ts
@@ -16,6 +16,20 @@ export const useMonthlyTokenUsage = () => {
     isReady.value = false
   }
 
+  const syncCurrentMonthUsage = (value: number | string | null | undefined) => {
+    if (value === null || value === undefined) {
+      return
+    }
+
+    const normalizedTotal = Number(value)
+    if (!Number.isFinite(normalizedTotal)) {
+      return
+    }
+
+    totalTokens.value = normalizedTotal
+    isReady.value = true
+  }
+
   const fetchCurrentMonthUsage = async () => {
     if (!import.meta.client || !token.value) {
       clear()
@@ -41,5 +55,6 @@ export const useMonthlyTokenUsage = () => {
     isReady,
     clear,
     fetchCurrentMonthUsage,
+    syncCurrentMonthUsage,
   }
 }

--- a/frontend/app/composables/useScanJob.ts
+++ b/frontend/app/composables/useScanJob.ts
@@ -10,6 +10,7 @@ type ScanJob = {
   error_message?: string | null
   created_at?: string | null
   updated_at?: string | null
+  current_month_total_tokens?: number | string | null
 }
 
 const BOOTSTRAP_STALLED_SCAN_JOB_ERROR_MESSAGE = 'Scan job stalled before repository progress started.'
@@ -100,7 +101,7 @@ const finalizeStaleJob = (job: ScanJob) => {
 
 export const useScanJob = () => {
   const { authedFetch } = useAuthedFetch()
-  const { fetchCurrentMonthUsage } = useMonthlyTokenUsage()
+  const { fetchCurrentMonthUsage, syncCurrentMonthUsage } = useMonthlyTokenUsage()
   const { t } = useI18n()
 
   const activeOrg = useState<string>('scan.activeOrg', () => '')
@@ -238,6 +239,10 @@ export const useScanJob = () => {
     const effectiveJob = isScanJobStale(normalizedJob)
       ? finalizeStaleJob(normalizedJob as ScanJob)
       : normalizedJob
+
+    if (normalizedJob?.current_month_total_tokens !== undefined) {
+      syncCurrentMonthUsage(normalizedJob.current_month_total_tokens)
+    }
 
     activeJob.value = effectiveJob
 

--- a/frontend/tests/unit/index-page.test.ts
+++ b/frontend/tests/unit/index-page.test.ts
@@ -42,6 +42,7 @@ const IndexHarness = defineComponent({
     auth.setAuth('token-1', 'octocat', [{ id: 1, login: 'octocat' }])
     return {
       ...auth,
+      ...useMonthlyTokenUsage(),
       ...useScanJob(),
     }
   },
@@ -60,6 +61,21 @@ const IndexStateResetHarness = defineComponent({
 
     return () => null
   },
+})
+
+const ScanJobUsageHarness = defineComponent({
+  setup() {
+    const monthlyUsage = useMonthlyTokenUsage()
+    const scanJob = useScanJob()
+    monthlyUsage.clear()
+    scanJob.resetState()
+
+    return {
+      ...monthlyUsage,
+      ...scanJob,
+    }
+  },
+  template: '<div />',
 })
 
 const baseRepository = {
@@ -799,6 +815,28 @@ describe('Index page', () => {
     ])
     expect(wrapper.vm.scanJobStatusLabel).toBe('Scan job queued')
     expect(wrapper.vm.scanJobDetailLabel).toBe('Preparing repository scan...')
+  })
+
+  it('updates monthly token usage state from scan job payload snapshots', async () => {
+    const wrapper = await mountSuspended(ScanJobUsageHarness)
+
+    wrapper.vm.syncJobState({
+      job_id: 'job-1',
+      org_id: 'octocat',
+      status: 'running',
+      total_repos: 3,
+      completed_repos: 1,
+      failed_repos: 0,
+      started_at: '2026-03-28T12:00:01',
+      finished_at: null,
+      error_message: null,
+      created_at: '2026-03-28T12:00:00',
+      updated_at: '2026-03-28T12:00:03',
+      current_month_total_tokens: 201,
+    })
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.vm.totalTokens).toBe(201)
   })
 
   it('treats string job counts as numbers when rendering bootstrap progress', async () => {


### PR DESCRIPTION
## What changed
- replaced scan job shared counter updates with per-repository progress records
- made scan job processing idempotent and retry-safe under Aurora DSQL serialization conflicts and message redelivery
- included monthly token usage snapshots in scan job API responses so the header usage counter updates during scan polling

## Why
A scan job could stay in `running` when concurrent counter updates hit serialization conflicts while repository messages were still being processed. The same flow also risked double counting under redelivery. Separately, the frontend usage header only refreshed at scan start and completion, which made in-progress token consumption hard to track.

## Impact
- scan jobs now reach terminal states reliably even when bookkeeping retries are exhausted
- duplicate repository deliveries do not double count progress
- the header token counter follows scan job polling without adding a separate usage polling loop

## Root cause
The previous implementation updated a single `scan_jobs` row for progress accounting from multiple concurrent workers. That row became a write hotspot, and retries were not enough to guarantee terminalization under contention.

## Validation
- `make test-unit-backend`
- `make test-integration`
- `make test-unit-frontend`
- `make lint-frontend`